### PR TITLE
Doc20240112

### DIFF
--- a/docs/cxx20-range-adaptor.md
+++ b/docs/cxx20-range-adaptor.md
@@ -18,7 +18,7 @@ int main() {
 This code wants to convert a single Unicode code-point 😀 (U+1F600 GRINNING FACE) from UTF-32 to UTF-16.
 As in the previous examples, the `out` vector will contain a two UTF-16 code units 0xD83D and 0xDE00.
 
-You can experiment with a working example using [Compiler Explorer](https://godbolt.org/z/EjvqGdErx).
+You can experiment with a working example using [Compiler Explorer](https://godbolt.org/z/z94x9dvh3).
 
 ### Disecting this code
 

--- a/tests/iconv/iconv.cpp
+++ b/tests/iconv/iconv.cpp
@@ -145,7 +145,7 @@ std::vector<C> convert_using_icubaby (std::vector<char32_t> const &in) {
 std::vector<char32_t> all_code_points () {
   std::vector<char32_t> result;
   for (auto cp = char32_t{0}; cp <= icubaby::max_code_point; ++cp) {
-    if (!icubaby::is_surrogate (cp) && cp != icubaby::bom) {
+    if (!icubaby::is_surrogate (cp) && cp != icubaby::byte_order_mark) {
       result.push_back (cp);
     }
   }


### PR DESCRIPTION
* Add a well_formed() member function to the range adaptor
* Link to a new range example on Compiler Explorer
* Rename "bom" as "byte_order_mark"