### PR TITLE
Fix incomplete sequences in the range-adaptor and UTF-32->UTF-16 surrogate input

### DIFF
--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -1085,7 +1085,6 @@ public:
 private:
   std::ranges::iterator_t<View> current_{};
   transcode_view const* parent_ = nullptr;
-  static value_type const replacement = icubaby::replacement_char;
 
   class state {
   public:
@@ -1120,11 +1119,6 @@ private:
   };
   mutable state state_{};
 };
-
-template <unicode_char_type FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
-  requires std::ranges::view<View>
-transcode_view<FromEncoding, ToEncoding, View>::iterator::value_type const
-transcode_view<FromEncoding, ToEncoding, View>::iterator::replacement;
 
 template <unicode_char_type FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
   requires std::ranges::view<View>

--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -1045,7 +1045,9 @@ public:
   constexpr std::ranges::iterator_t<View> const& base () const& noexcept { return current_; }
   constexpr std::ranges::iterator_t<View> base () && { return std::move (current_); }
 
-  constexpr value_type const& operator* () const { return state_.front (); }
+  constexpr value_type const& operator* () const {
+    return state_.empty () ? replacement : state_.front ();
+  }
   constexpr std::ranges::iterator_t<View> operator->() const { return state_.front (); }
 
   constexpr iterator& operator++ () {
@@ -1085,6 +1087,7 @@ public:
 private:
   std::ranges::iterator_t<View> current_{};
   transcode_view const* parent_ = nullptr;
+  static value_type const replacement = icubaby::replacement_char;
 
   class state {
   public:
@@ -1116,6 +1119,11 @@ private:
   };
   mutable state state_{};
 };
+
+template <unicode_char_type FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
+  requires std::ranges::view<View>
+transcode_view<FromEncoding, ToEncoding, View>::iterator::value_type const
+transcode_view<FromEncoding, ToEncoding, View>::iterator::replacement;
 
 template <unicode_char_type FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
   requires std::ranges::view<View>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable (icubaby-unittests
   harness.cpp
   test_u8_32.cpp
   test_u16.cpp
+  test_u32.cpp
   test_u32_8.cpp
   test_utility.cpp
   typed_test.hpp

--- a/unittests/test_u32.cpp
+++ b/unittests/test_u32.cpp
@@ -1,0 +1,252 @@
+// MIT License
+//
+// Copyright (c) 2022-2024 Paul Bowen-Huggett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <array>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// icubaby itself.
+#include "icubaby/icubaby.hpp"
+
+// Google Test/Mock
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// Local includes
+#include "encoded_char.hpp"
+#include "typed_test.hpp"
+
+static_assert (std::is_same_v<icubaby::t32_8 ::input_type, char32_t> &&
+               std::is_same_v<icubaby::t32_8 ::output_type, icubaby::char8>);
+static_assert (std::is_same_v<icubaby::t32_16::input_type, char32_t> &&
+               std::is_same_v<icubaby::t32_16::output_type, char16_t>);
+// NOLINTNEXTLINE(misc-redundant-expression)
+static_assert (std::is_same_v<icubaby::t32_32::input_type, char32_t> &&
+               std::is_same_v<icubaby::t32_32::output_type, char32_t>);
+
+using namespace std::string_literals;
+using testing::ElementsAreArray;
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+namespace {
+
+template <typename T> class Utf32 : public testing::Test {
+protected:
+  using output_type = T;
+  std::vector<output_type> output_;
+  icubaby::transcoder<char32_t, output_type> transcoder_;
+};
+
+}  // end anonymous namespace
+
+TYPED_TEST_SUITE (Utf32, OutputTypes, OutputTypeNames);
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, GoodDollarSign) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  auto it = transcoder (static_cast<char32_t> (code_point::dollar_sign), std::back_inserter (output));
+  EXPECT_TRUE (transcoder.well_formed ()) << "input should be well formed";
+  EXPECT_FALSE (transcoder.partial ()) << "there were no surrogate code units";
+  transcoder.end_cp (it);
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::dollar_sign, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, StartOfHeadingAndText) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+  auto it = transcoder (static_cast<char32_t> (code_point::start_of_heading), std::back_inserter (output));
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  it = transcoder (static_cast<char32_t> (code_point::start_of_text), it);
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+
+  std::vector<TypeParam> expected;
+  append<code_point::start_of_heading, TypeParam> (std::back_inserter (expected));
+  append<code_point::start_of_text, TypeParam> (std::back_inserter (expected));
+  EXPECT_THAT (output, ElementsAreArray (expected));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, CharFFFF) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+  auto it = transcoder (static_cast<char32_t> (code_point::code_point_ffff), std::back_inserter (output));
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::code_point_ffff, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, FirstHighSurrogate) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (icubaby::first_high_surrogate, std::back_inserter (output));
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, LastHighSurrogate) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (icubaby::last_high_surrogate, std::back_inserter (output));
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, FirstLowSurrogate) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (icubaby::first_low_surrogate, std::back_inserter (output));
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, LastLowSurrogate) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (icubaby::last_low_surrogate, std::back_inserter (output));
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, MaxCodePoint) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (icubaby::max_code_point, std::back_inserter (output));
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_TRUE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::last_valid_code_point, TypeParam>));
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, BeyondMaxCodePoint) {
+  auto& transcoder = this->transcoder_;
+  auto& output = this->output_;
+
+  auto it = transcoder (static_cast<char32_t> (static_cast<std::uint_least32_t> (icubaby::max_code_point) + 1U),
+                        std::back_inserter (output));
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+  transcoder.end_cp (it);
+  EXPECT_FALSE (transcoder.well_formed ());
+  EXPECT_FALSE (transcoder.partial ());
+
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+}
+
+#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, RangesCopy) {
+  auto& output = this->output_;
+
+  std::vector const in{
+      static_cast<char32_t> (code_point::cjk_unified_ideograph_2070e),
+      static_cast<char32_t> (code_point::code_point_ffff),
+      static_cast<char32_t> (code_point::cuneiform_sign_uru_times_ki),
+      static_cast<char32_t> (code_point::dollar_sign),
+      static_cast<char32_t> (code_point::hiragana_letter_go),
+      static_cast<char32_t> (code_point::hiragana_letter_ha),
+      static_cast<char32_t> (code_point::hiragana_letter_i),
+      static_cast<char32_t> (code_point::hiragana_letter_ma),
+      static_cast<char32_t> (code_point::hiragana_letter_o),
+      static_cast<char32_t> (code_point::hiragana_letter_su),
+      static_cast<char32_t> (code_point::hiragana_letter_u),
+      static_cast<char32_t> (code_point::hiragana_letter_yo),
+      static_cast<char32_t> (code_point::hiragana_letter_za),
+      static_cast<char32_t> (code_point::linear_b_syllable_b008_a),
+      static_cast<char32_t> (code_point::start_of_heading),
+      static_cast<char32_t> (code_point::start_of_text),
+  };
+
+  auto r = in | icubaby::ranges::transcode<char32_t, TypeParam>;
+  std::ranges::copy (r, std::back_inserter (output));
+
+  std::vector<TypeParam> expected;
+  append<code_point::cjk_unified_ideograph_2070e, TypeParam> (std::back_inserter (expected));
+  append<code_point::code_point_ffff, TypeParam> (std::back_inserter (expected));
+  append<code_point::cuneiform_sign_uru_times_ki, TypeParam> (std::back_inserter (expected));
+  append<code_point::dollar_sign, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_go, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_ha, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_i, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_ma, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_o, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_su, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_u, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_yo, TypeParam> (std::back_inserter (expected));
+  append<code_point::hiragana_letter_za, TypeParam> (std::back_inserter (expected));
+  append<code_point::linear_b_syllable_b008_a, TypeParam> (std::back_inserter (expected));
+  append<code_point::start_of_heading, TypeParam> (std::back_inserter (expected));
+  append<code_point::start_of_text, TypeParam> (std::back_inserter (expected));
+  EXPECT_THAT (output, ElementsAreArray (expected));
+  EXPECT_TRUE (r.well_formed ());
+}
+// NOLINTNEXTLINE
+TYPED_TEST (Utf32, RangesBadInput) {
+  auto& output = this->output_;
+  std::vector const in{char32_t{0xFFFFFFFF}};
+  auto const r = in | icubaby::ranges::transcode<char32_t, TypeParam>;
+  std::ranges::copy (r, std::back_inserter (output));
+  EXPECT_THAT (output, ElementsAreArray (encoded_char_v<code_point::replacement_char, TypeParam>));
+  EXPECT_FALSE (r.well_formed ());
+}
+
+#endif  // ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)

--- a/unittests/test_u32_8.cpp
+++ b/unittests/test_u32_8.cpp
@@ -95,4 +95,14 @@ TEST (Utf32To8, RangesCopy) {
   ));
   // clang-format on
 }
+// NOLINTNEXTLINE
+TEST (Utf32To8, RangesBadInput) {
+  std::vector const in{char32_t{0xFFFFFFFF}};
+  std::vector<char8_t> out8;
+  auto const r = in | icubaby::ranges::transcode<char32_t, char8_t>;
+  std::ranges::copy (r, std::back_inserter (out8));
+  EXPECT_THAT (out8, testing::ElementsAre (char8_t{0xEF}, char8_t{0xBF}, char8_t{0xBD}));
+  EXPECT_FALSE (r.well_formed ());
+}
+
 #endif  // __cpp_lib_ranges

--- a/unittests/test_u8_32.cpp
+++ b/unittests/test_u8_32.cpp
@@ -277,8 +277,23 @@ TEST (Utf8To32, RangesCopy) {
   };
   // clang-format on
   std::vector<char32_t> out32;
-  std::ranges::copy (in | icubaby::ranges::transcode<char8_t, char32_t>, std::back_inserter (out32));
+  auto const r = in | icubaby::ranges::transcode<char8_t, char32_t>;
+  std::ranges::copy (r, std::back_inserter (out32));
   EXPECT_THAT (out32, testing::ElementsAre (char32_t{0x3053}, char32_t{0x3093}, char32_t{0x306B}, char32_t{0x3061},
                                             char32_t{0x306F}, char32_t{0x4E16}, char32_t{0x754C}, char32_t{0x000A}));
+  EXPECT_TRUE (r.well_formed());
 }
+TEST (Utf8To32, RangesBadInput) {
+  // clang-format off
+  std::vector const in{
+    char8_t{0xF3}, char8_t{0x81},
+  };
+  // clang-format on
+  std::vector<char32_t> out32;
+  auto const r = in | icubaby::ranges::transcode<char8_t, char32_t>;
+  std::ranges::copy (r, std::back_inserter (out32));
+  EXPECT_THAT (out32, testing::ElementsAre (char32_t{icubaby::replacement_char}));
+  EXPECT_FALSE (r.well_formed());
+}
+
 #endif  // __cpp_lib_ranges


### PR DESCRIPTION
There was a bug in the handling of surrogate values in the UTF-32->UTF-16 conversion. The code dealt with the <= 0xFFFF case *before* considering the surrogate case (the high/low surrogate values *are* <= 0xFFFF)!

The range adaptor had a bug in the handling of an incomplete code-unit sequence at the end of the input this could result in a code-unit of zero being produced. We now consider the end-of-input case after consuming the input bytes to avoid this problem. Added some additional assertions.

Added new, more thorough, testing for the UTF-32 to 8/16/32 cases.