### PR TITLE
Add ICUBABY_SANITIZER switch.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,15 @@ jobs:
             apt_install: cmake g++-13 libstdc++-13-dev ninja-build
             build_type: Debug
             cxx_compiler: -DCMAKE_CXX_COMPILER=g++-13 -DCMAKE_C_COMPILER=gcc-13
+            options: -DICUBABY_SANITIZE=Yes
+            generator: Ninja
+            os: ubuntu-22.04
+
+          - name: Ubuntu-22.04/gcc-13/RelWithDebug/Sanitizers
+            apt_install: cmake g++-13 libstdc++-13-dev ninja-build
+            build_type: RelWithDebug
+            cxx_compiler: -DCMAKE_CXX_COMPILER=g++-13 -DCMAKE_C_COMPILER=gcc-13
+            options: -DICUBABY_SANITIZE=Yes
             generator: Ninja
             os: ubuntu-22.04
 
@@ -43,7 +52,7 @@ jobs:
             build_type: Debug
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-16 -DCMAKE_C_COMPILER=clang-16
             generator: Ninja
-            options: -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -DICUBABY_SANITIZE=Yes
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-16/Release
@@ -52,7 +61,7 @@ jobs:
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-16 -DCMAKE_C_COMPILER=clang-16
             generator: Ninja
-            options: -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options:
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-14/Release/C++17
@@ -60,7 +69,7 @@ jobs:
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
             generator: Ninja
-            options: -DICUBABY_CXX17=Yes -DICUBABY_LIBCXX=Yes -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -DICUBABY_CXX17=Yes -DICUBABY_LIBCXX=Yes
             os: ubuntu-22.04
 
           # Windows builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,12 @@ cmake_minimum_required(VERSION 3.22)
 
 project (icubaby CXX)
 
-option (ICUBABY_WERROR "Compiler warnings are errors")
+option (ICUBABY_COVERAGE "Generate LLVM Source-based Coverage")
 option (ICUBABY_CXX17 "Use C++17 (rather than the default C++20)")
 option (ICUBABY_FUZZTEST "Enable FuzzTest")
 option (ICUBABY_LIBCXX "Use libc++ rather than libstdc++ (clang only)")
-option (ICUBABY_COVERAGE "Generate LLVM Source-based Coverage")
+option (ICUBABY_SANITIZE "Enable undefined behavior- and address-sanitizers where supported")
+option (ICUBABY_WERROR "Compiler warnings are errors")
 
 set (icubaby_project_root "${CMAKE_CURRENT_SOURCE_DIR}")
 list (APPEND CMAKE_MODULE_PATH "${icubaby_project_root}/cmake")

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -65,6 +65,10 @@ function (setup_target target)
     list (APPEND clang_options -fprofile-instr-generate -fcoverage-mapping)
     list (APPEND gcc_options -fprofile-arcs -ftest-coverage)
   endif ()
+  if (ICUBABY_SANITIZE)
+    list (APPEND clang_options -fsanitize=undefined -fsanitize=address)
+    list (APPEND gcc_options -fsanitize=undefined -fsanitize=address -fno-sanitize-recover)
+  endif ()
 
   target_compile_features (${target} PUBLIC $<IF:$<BOOL:${ICUBABY_CXX17}>,cxx_std_17,cxx_std_20>)
   target_compile_options (${target} PRIVATE


### PR DESCRIPTION
This enables ubsan and asan on clang and gcc builds.