### PR TITLE
Save and restore the iostream state. Use std::format() when available.

### DIFF
--- a/tests/demo8/demo8.cpp
+++ b/tests/demo8/demo8.cpp
@@ -31,7 +31,28 @@
 
 namespace {
 
+/// \brief A class used to save an iostream's formatting flags on construction
+/// and restore them on destruction.
+///
+/// Used to manage the restoration of the flags on exit from a scope.
+class ios_flags_saver {
+public:
+  explicit ios_flags_saver (std::ios_base& stream) : stream_{stream}, flags_{stream.flags ()} {}
+  ios_flags_saver (ios_flags_saver const&) = delete;
+  ios_flags_saver (ios_flags_saver&&) noexcept = delete;
+
+  ~ios_flags_saver () { stream_.flags (flags_); }
+
+  ios_flags_saver& operator= (ios_flags_saver const&) = delete;
+  ios_flags_saver& operator= (ios_flags_saver&&) noexcept = delete;
+
+private:
+  std::ios_base& stream_;
+  std::ios_base::fmtflags flags_;
+};
+
 template <typename StringType> void show (std::ostream& os, StringType const& str) {
+  ios_flags_saver s{os};
   os << std::setfill ('0') << std::hex;
   auto const* separator = "";
   for (auto const c : str) {

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -36,7 +36,6 @@
 #include <format>
 #else
 // We're lacking std::format(). Fall back to using iostreams manipulators.
-#define HAVE_CPP_LIB_FORMAT (0)
 #include <iomanip>
 #endif
 

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -32,11 +32,14 @@
 
 // Do we have library support for C++ 20 std::format()?
 #if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#define HAVE_CPP_LIB_FORMAT (1)
 #include <format>
 #else
 // We're lacking std::format(). Fall back to using iostreams manipulators.
+#define HAVE_CPP_LIB_FORMAT (0)
 #include <iomanip>
 #endif
+
 // Do we have library support for C++ 20 ranges?
 #if defined(__cpp_lib_ranges) && __cpp_lib_ranges > 201811L
 #include <ranges>
@@ -95,7 +98,7 @@ template <> struct char_to_output_type<char32_t> {
   using type = std::uint_least32_t;
 };
 
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#if HAVE_CPP_LIB_FORMAT
 
 template <icubaby::unicode_char_type CharType>
 std::ostream& dump_vector (std::ostream& os, std::vector<CharType> const& v) {
@@ -153,7 +156,7 @@ std::ostream& dump_vector (std::ostream& os, std::vector<CharType> const& v) {
   return os;
 }
 
-#endif
+#endif  // HAVE_CPP_LIB_FORMAT
 
 template <std::ranges::input_range ActualRange, std::ranges::input_range ExpectedRange>
 void check (ActualRange const& actual, ExpectedRange const& expected) {
@@ -205,7 +208,12 @@ template <std::ranges::input_range Range> std::vector<char32_t> convert_16_to_32
 
   std::cout << "Convert the UTF-16 stream to UTF-32:\n ";
   dump_vector (std::cout, out32);
-  std::cout << " well formed? " << r.well_formed () << '\n';
+#if HAVE_CPP_LIB_FORMAT
+  std::cout << std::format (" well formed? {}\n", r.well_formed ());
+#else
+  ios_flags_saver _{std::cout};
+  std::cout << " well formed? " << std::boolalpha << r.well_formed () << '\n';
+#endif
 
   check (out32, expected32);
   return out32;
@@ -218,7 +226,12 @@ template <std::ranges::input_range Range> std::vector<char8_t> convert_16_to_8 (
   std::cout << "Convert the UTF-16 stream to UTF-8:\n ";
   std::ranges::copy (r, std::back_inserter (out8));
   dump_vector (std::cout, out8);
-  std::cout << " well formed? " << r.well_formed () << '\n';
+#if HAVE_CPP_LIB_FORMAT
+  std::cout << std::format (" well formed? {}\n", r.well_formed ());
+#else
+  ios_flags_saver _{std::cout};
+  std::cout << " well formed? " << std::boolalpha << r.well_formed () << '\n';
+#endif
 
   return out8;
 }
@@ -227,7 +240,11 @@ template <std::ranges::input_range Range> std::vector<char8_t> convert_16_to_8 (
 
 int main () {
   auto const& in = expected8;
-  std::cout << std::boolalpha << "input length is " << icubaby::length (in) << " code-points\n";
+#if HAVE_CPP_LIB_FORMAT
+  std::cout << std::format ("input length is {} code points\n", icubaby::length (in));
+#else
+  std::cout << "input length is " << icubaby::length (in) << " code-points\n";
+#endif
 
   auto const out16 = convert_8_to_16 (in);
   auto const out32 = convert_8_to_32 (in);

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -108,11 +108,7 @@ std::ostream& dump_vector (std::ostream& os, std::vector<CharType> const& v) {
     if constexpr (std::is_same_v<CharType, char8_t>) {
       os << std::format ("{}0x{:02X}", separator, oc);
     } else {
-      if (oc > 0xFFFF) {
-        os << std::format ("{}0x{:04X}", separator, oc);
-      } else {
-        os << std::format ("{}0x{:X}", separator, oc);
-      }
+      os << std::format ("{}0x{:04X}", separator, oc);
     }
     separator = " ";
   }


### PR DESCRIPTION
This applies to the demo/test tools. The core library is not affected.