### PR TITLE
Add an extended set of unit tests for bad UTF-8 input.

### DIFF
--- a/unittests/encoded_char.hpp
+++ b/unittests/encoded_char.hpp
@@ -55,6 +55,10 @@ enum class code_point : char32_t {
   hiragana_letter_za = char32_t{0x3056},
   line_feed = char32_t{0x000A},
   linear_b_syllable_b008_a = char32_t{0x10000},
+  pilcrow_sign = char32_t{0x00B6},
+  pile_of_poop = char32_t{0x1F4A9},
+  snowman = char32_t{0x2603},
+
   replacement_char = icubaby::replacement_char,
   start_of_heading = char32_t{0x001},
   start_of_text = char32_t{0x002},
@@ -124,6 +128,38 @@ template <> struct encoded_char<code_point::cent_sign, char16_t> {
 };
 template <> struct encoded_char<code_point::cent_sign, icubaby::char8> {
   static constexpr std::array value{static_cast<icubaby::char8> (0xC2), static_cast<icubaby::char8> (0xA2)};
+};
+
+template <> struct encoded_char<code_point::pilcrow_sign, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::pilcrow_sign)};
+};
+template <> struct encoded_char<code_point::pilcrow_sign, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::pilcrow_sign)};
+};
+template <> struct encoded_char<code_point::pilcrow_sign, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (0xC2), static_cast<icubaby::char8> (0xB6)};
+};
+
+template <> struct encoded_char<code_point::pile_of_poop, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::pile_of_poop)};
+};
+template <> struct encoded_char<code_point::pile_of_poop, char16_t> {
+  static constexpr std::array value{char16_t{0xD83D}, char16_t{0xDCA9}};
+};
+template <> struct encoded_char<code_point::pile_of_poop, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (0xF0), static_cast<icubaby::char8> (0x9F),
+                                    static_cast<icubaby::char8> (0x92), static_cast<icubaby::char8> (0xA9)};
+};
+
+template <> struct encoded_char<code_point::snowman, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::snowman)};
+};
+template <> struct encoded_char<code_point::snowman, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::snowman)};
+};
+template <> struct encoded_char<code_point::snowman, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (0xE2), static_cast<icubaby::char8> (0x98),
+                                    static_cast<icubaby::char8> (0x83)};
 };
 
 template <> struct encoded_char<code_point::replacement_char, char32_t> {

--- a/unittests/test_u8.cpp
+++ b/unittests/test_u8.cpp
@@ -275,7 +275,247 @@ TYPED_TEST (Utf8, PartialEndCp) {
   EXPECT_THAT (output, ContainerEq (expected));
 }
 
+namespace {
+
+// The tests built with this fixture are derived from the "broken UTF-8" test page
+// found here <https://hsivonen.fi/broken-utf-8/test.html>
+template <typename OutputChar> class Utf8BadInput : public testing::Test {
+protected:
+  template <typename... Args> static std::vector<OutputChar> convert (Args&&... args) {
+    icubaby::transcoder<icubaby::char8, OutputChar> transcoder;
+    std::vector<OutputChar> output;
+    add8 (transcoder, std::back_inserter (output), std::forward<Args> (args)...);
+    return output;
+  }
+
+  static auto is_expected (std::size_t num) {
+    std::vector<OutputChar> expected;
+    replacement_chars (expected, num);
+    return ContainerEq (expected);
+  }
+
+private:
+  template <typename OutputIterator>
+  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out,
+                              std::uint_least8_t c) {
+    return transcoder.end_cp (transcoder (static_cast<icubaby::char8> (c), out));
+  }
+  template <typename OutputIterator, typename... Args>
+  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out,
+                              std::uint_least8_t c, Args... args) {
+    return add8 (transcoder, transcoder (static_cast<icubaby::char8> (c), out), args...);
+  }
+
+  static void replacement_chars (std::vector<OutputChar>& v, std::size_t num) {
+    if (num == 0U) {
+      return;
+    }
+    append<code_point::replacement_char, OutputChar> (std::back_inserter (v));
+    replacement_chars (v, num - 1U);
+  }
+};
+
+}  // end anonymous namespace
+
+TYPED_TEST_SUITE (Utf8BadInput, OutputTypes, OutputTypeNames);
+
+// Non-shortest forms for lowest single-byte (U+0000)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForLowestSingleByte) {
+  // Two-byte sequence (C0 80)
+  EXPECT_THAT (this->convert (0xC0, 0x80), this->is_expected (2));
+  // Three-byte sequence (E0 80 80)
+  EXPECT_THAT (this->convert (0xE0, 0x80, 0x80), this->is_expected (2));
+  // Four-byte sequence (F0 80 80 80)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x80), this->is_expected (3));
+  // Five-byte sequence (F8 80 80 80 80)
+  EXPECT_THAT (this->convert (0xF8, 0x80, 0x80, 0x80, 0x80), this->is_expected (5));
+  // Six-byte sequence (FC 80 80 80 80 80)
+  EXPECT_THAT (this->convert (0xFC, 0x80, 0x80, 0x80, 0x80, 0x80), this->is_expected (6));
+}
+
+// Non-shortest forms for highest single-byte (U+007F)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForHighestSingleByte) {
+  // Two-byte sequence (C1 BF)
+  EXPECT_THAT (this->convert (0xC1, 0xBF), this->is_expected (2));
+  // Three-byte sequence (E0 81 BF)
+  EXPECT_THAT (this->convert (0xE0, 0x81, 0xBF), this->is_expected (2));
+  // Four-byte sequence (F0 80 81 BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x81, 0xBF), this->is_expected (3));
+  // Five-byte sequence (F8 80 80 81 BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x81, 0xBF), this->is_expected (4));
+  // Six-byte sequence (FC 80 80 80 81 BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x80, 0x81, 0xBF), this->is_expected (5));
+}
+
+// Non-shortest forms for lowest two-byte (U+0080)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForLowestTwoByte) {
+  // Three-byte sequence (E0 82 80)
+  EXPECT_THAT (this->convert (0xE0, 0x82, 0x80), this->is_expected (2));
+  // Four-byte sequence (F0 80 82 80)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x82, 0x80), this->is_expected (3));
+  // Five-byte sequence (F8 80 80 82 80)
+  EXPECT_THAT (this->convert (0xF8, 0x80, 0x80, 0x82, 0x80), this->is_expected (5));
+  // Six-byte sequence (FC 80 80 80 82 80)
+  EXPECT_THAT (this->convert (0xFC, 0x80, 0x80, 0x80, 0x82, 0x80), this->is_expected (6));
+}
+
+// Non-shortest forms for highest two-byte (U+07FF)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForHighestTwoByte) {
+  // Three-byte sequence (E0 9F BF)
+  EXPECT_THAT (this->convert (0xE0, 0x9F, 0xBF), this->is_expected (2));
+  // Four-byte sequence (F0 80 9F BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x9F, 0xBF), this->is_expected (3));
+  // Five-byte sequence (F8 80 80 9F BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x9F, 0xBF), this->is_expected (4));
+  // Six-byte sequence (FC 80 80 80 9F BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x80, 0x9F, 0xBF), this->is_expected (5));
+}
+
+// Non-shortest forms for lowest three-byte (U+0800)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForLowestThreeByte) {
+  // Four-byte sequence (F0 80 A0 80)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0xA0, 0x80), this->is_expected (3));
+  // Five-byte sequence (F8 80 80 A0 80)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0xA0, 0x80), this->is_expected (4));
+  // Six-byte sequence (FC 80 80 80 A0 80)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x80, 0xA0, 0x80), this->is_expected (5));
+}
+
+// Non-shortest forms for highest three-byte (U+FFFF)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForHighestThreeByte) {
+  // Four-byte sequence (F0 8F BF BF)
+  EXPECT_THAT (this->convert (0xF0, 0x8F, 0xBF, 0xBF), this->is_expected (3));
+  // Five-byte sequence (F8 80 8F BF BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x8F, 0xBF, 0xBF), this->is_expected (4));
+  // Six-byte sequence (FC 80 80 8F BF BF)
+  EXPECT_THAT (this->convert (0xF0, 0x80, 0x80, 0x8F, 0xBF, 0xBF), this->is_expected (5));
+}
+
+// Non-shortest forms for lowest four-byte (U+10000)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForLowestFourByte) {
+  // Five-byte sequence (F8 80 90 80 80)
+  EXPECT_THAT (this->convert (0xF8, 0x80, 0x90, 0x80, 0x80), this->is_expected (5));
+  // Six-byte sequence (FC 80 80 90 80 80)
+  EXPECT_THAT (this->convert (0xFC, 0x80, 0x80, 0x90, 0x80, 0x80), this->is_expected (6));
+}
+
+// Non-shortest forms for last Unicode (U+10FFFF)
+TYPED_TEST (Utf8BadInput, NonShortestFormsForLastUnicode) {
+  // Five-byte sequence (F8 84 8F BF BF)
+  EXPECT_THAT (this->convert (0xF8, 0x84, 0x8F, 0xBF, 0xBF), this->is_expected (5));
+  // Six-byte sequence (FC 80 84 8F BF BF)
+  EXPECT_THAT (this->convert (0xF8, 0x84, 0x8F, 0xBF, 0xBF, 0xBF), this->is_expected (6));
+}
+
+// Out of range
+TYPED_TEST (Utf8BadInput, OutOfRange) {
+  // One past Unicode (F4 90 80 80)
+  EXPECT_THAT (this->convert (0xF7, 0x90, 0x80, 0x80), this->is_expected (4));
+  // Longest five-byte sequence (FB BF BF BF BF)
+  EXPECT_THAT (this->convert (0xFC, 0xBF, 0xBF, 0xBF, 0xBF), this->is_expected (5));
+  // Longest six-byte sequence (FD BF BF BF BF BF)
+  EXPECT_THAT (this->convert (0xFC, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF), this->is_expected (6));
+  // First surrogate (ED A0 80)
+  EXPECT_THAT (this->convert (0xED, 0xA0, 0x80), this->is_expected (2));
+  // Last surrogate (ED BF BF)
+  EXPECT_THAT (this->convert (0xED, 0xBF, 0xBF), this->is_expected (2));
+  // CESU-8 surrogate pair (ED A0 BD ED B2 A9)
+  EXPECT_THAT (this->convert (0xED, 0xA0, 0xBD, 0xED, 0xB2, 0xA9), this->is_expected (4));
+}
+
+// Out of range and non-shortest
+TYPED_TEST (Utf8BadInput, OutOfRangeAndNonShortest) {
+  // One past Unicode as five-byte sequence (F8 84 90 80 80)
+  EXPECT_THAT (this->convert (0xF8, 0x84, 0x90, 0x80, 0x80), this->is_expected (5));
+  // One past Unicode as six-byte sequence (FC 80 84 90 80 80)
+  EXPECT_THAT (this->convert (0xFC, 0x80, 0x84, 0x90, 0x80, 0x80), this->is_expected (6));
+  // First surrogate as four-byte sequence (F0 8D A0 80)
+  EXPECT_THAT (this->convert (0xF0, 0x8D, 0xA0, 0x80), this->is_expected (3));
+  // Last surrogate as four-byte sequence (F0 8D BF BF)
+  EXPECT_THAT (this->convert (0xF0, 0x8D, 0xBF, 0xBF), this->is_expected (3));
+  // CESU-8 surrogate pair as two four-byte overlongs (F0 8D A0 BD F0 8D B2 A9)
+  EXPECT_THAT (this->convert (0xF0, 0x8D, 0xA0, 0xBD, 0xF0, 0x8D, 0xB2, 0xA9), this->is_expected (6));
+}
+
+// Lone trails
+TYPED_TEST (Utf8BadInput, LoneTrails) {
+  // One (80)
+  EXPECT_THAT (this->convert (0x80), this->is_expected (1));
+  // Two (80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80), this->is_expected (2));
+  // Three (80 80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80, 0x80), this->is_expected (3));
+  // Four (80 80 80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80, 0x80, 0x80), this->is_expected (4));
+  // Five (80 80 80 80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80, 0x80, 0x80, 0x80), this->is_expected (5));
+  // Six (80 80 80 80 80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80, 0x80, 0x80, 0x80, 0x80), this->is_expected (6));
+  // Seven (80 80 80 80 80 80 80)
+  EXPECT_THAT (this->convert (0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80), this->is_expected (7));
+  // After five-byte (FB BF BF BF BF 80)
+  EXPECT_THAT (this->convert (0xFB, 0xBF, 0xBF, 0xBF, 0xBF, 0x80), this->is_expected (6));
+  // After six-byte (FD BF BF BF BF BF 80)
+  EXPECT_THAT (this->convert (0xFD, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF, 0x80), this->is_expected (7));
+}
+
+TYPED_TEST (Utf8BadInput, LoneTrailsAfterValidTwoByte) {
+  // After valid two-byte (C2 B6 80)
+  auto const output = this->convert (0xC2, 0xB6, 0x80);
+  std::vector<TypeParam> expected;
+  append<code_point::pilcrow_sign, TypeParam> (std::back_inserter (expected));
+  append<code_point::replacement_char, TypeParam> (std::back_inserter (expected));
+  EXPECT_THAT (output, ContainerEq (expected));
+}
+
+TYPED_TEST (Utf8BadInput, LoneTrailsAfterValidThreeByte) {
+  // After valid three-byte (E2 98 83 80)
+  auto const output = this->convert (0xE2, 0x98, 0x83, 0x80);
+  std::vector<TypeParam> expected;
+  append<code_point::snowman, TypeParam> (std::back_inserter (expected));
+  append<code_point::replacement_char, TypeParam> (std::back_inserter (expected));
+  EXPECT_THAT (output, ContainerEq (expected));
+}
+
+TYPED_TEST (Utf8BadInput, LoneTrailsAfterValidFourByte) {
+  // After valid four-byte (F0 9F 92 A9 80)
+  auto const output = this->convert (0xF0, 0x9F, 0x92, 0xA9, 0x80);
+  std::vector<TypeParam> expected;
+  append<code_point::pile_of_poop, TypeParam> (std::back_inserter (expected));
+  append<code_point::replacement_char, TypeParam> (std::back_inserter (expected));
+  EXPECT_THAT (output, ContainerEq (expected));
+}
+
+// Truncated sequences
+TYPED_TEST (Utf8BadInput, TruncatedSequences) {
+  // Two-byte lead (C2)
+  EXPECT_THAT (this->convert (0xC2), this->is_expected (1));
+  // Three-byte lead (E2)
+  EXPECT_THAT (this->convert (0xE2), this->is_expected (1));
+  // Three-byte lead and one trail (E2 98)
+  EXPECT_THAT (this->convert (0xE2, 0x98), this->is_expected (1));
+  // Four-byte lead (F0)
+  EXPECT_THAT (this->convert (0xF0), this->is_expected (1));
+  // Four-byte lead and one trail (F0 9F)
+  EXPECT_THAT (this->convert (0xF0, 0x9F), this->is_expected (1));
+  // Four-byte lead and two trails (F0 9F 92)
+  EXPECT_THAT (this->convert (0xF0, 0x9F, 0x92), this->is_expected (1));
+}
+
+// Leftovers
+TYPED_TEST (Utf8BadInput, Leftovers) {
+  // FE (FE)
+  EXPECT_THAT (this->convert (0xFE), this->is_expected (1));
+  // FE and trail (FE 80)
+  EXPECT_THAT (this->convert (0xFE, 0x80), this->is_expected (2));
+  // FF (FF)
+  EXPECT_THAT (this->convert (0xFF), this->is_expected (1));
+  // FF and trail (FF 80)
+  EXPECT_THAT (this->convert (0xFF, 0x80), this->is_expected (2));
+}
+
 #if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201811L
+
 // NOLINTNEXTLINE
 TYPED_TEST (Utf8, RangesCopy) {
   auto& output = this->output_;

--- a/unittests/test_u8.cpp
+++ b/unittests/test_u8.cpp
@@ -296,13 +296,18 @@ protected:
 
 private:
   template <typename OutputIterator>
-  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out,
-                              std::uint_least8_t c) {
+  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out, int c) {
+    if (c < 0 || c > 255) {
+      throw std::range_error ("character value out of range");
+    }
     return transcoder.end_cp (transcoder (static_cast<icubaby::char8> (c), out));
   }
   template <typename OutputIterator, typename... Args>
-  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out,
-                              std::uint_least8_t c, Args... args) {
+  static OutputIterator add8 (icubaby::transcoder<icubaby::char8, OutputChar>& transcoder, OutputIterator out, int c,
+                              Args... args) {
+    if (c < 0 || c > 255) {
+      throw std::range_error ("character value out of range");
+    }
     return add8 (transcoder, transcoder (static_cast<icubaby::char8> (c), out), args...);
   }
 


### PR DESCRIPTION
The tests were derived from this “broken UTF-8” [test page](https://hsivonen.fi/broken-utf-8/test.html).