### PR TITLE
Add codecov configuration file.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - unittests/*


### PR DESCRIPTION
Tell codecov to ignore the unittests directory.

Codecov docs say "Each repository may have their own unique Codecov YAML. The contents of the Repository YAML are stored in a file, checked into git/hg within the root of your repo." All of their documentation refers to this file as "codecov.yml": the three letter extension is irritating (it should be YAML not YML)!