### PR TITLE
Remove the SHA256 check on the llvm.sh file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,12 +108,6 @@ jobs:
         if: matrix.llvm_install != ''
         run: |
           wget https://apt.llvm.org/llvm.sh
-
-          # Verify that the file we downloaded is as we expected.
-          cat << 'EOF' | sha256sum --check
-          7dbc0855dff7d1a5b4eb71a209ab3dd9b8654d67e55daa1e49180dd1d97a1bcf  llvm.sh
-          EOF
-
           # Force --yes to the end of the add-apt-repository command to
           # prevent the llvm.sh script hanging.
           sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -34,12 +34,6 @@ jobs:
       - name: Install Dependencies (LLVM)
         run: |
           wget https://apt.llvm.org/llvm.sh
-
-          # Verify that the file we downloaded is as we expected.
-          cat << 'EOF' | sha256sum --check
-          7dbc0855dff7d1a5b4eb71a209ab3dd9b8654d67e55daa1e49180dd1d97a1bcf  llvm.sh
-          EOF
-
           # Force --yes to the end of the add-apt-repository command to
           # prevent the llvm.sh script hanging.
           sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh


### PR DESCRIPTION
This was intended to resolve the "Pinned Dependencies" warning from the OpenSSF scan. Unfortunately, it didn't do so and (of course) fails when the script changes upstream.