### PR TITLE
Cleaning up most of the extent clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,8 +4,8 @@ Checks:            |-
   -altera-*,
   -cert-dcl21-cpp,
   -cppcoreguidelines-avoid-magic-numbers,
-  -cppcoreguidelines-owning-memory,
   -fuchsia-*,
+  -llvm-header-guard,
   -llvmlibc-*,
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
@@ -14,7 +14,7 @@ Checks:            |-
 WarningsAsErrors:  ''
 HeaderFilterRegex: ''
 FormatStyle:       file
-User:              paul
+
 CheckOptions:
   - key:   cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
     value: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ does not allocate dynamic memory and neither throws or catches exceptions.
 
 | Category | Badges |
 | --- | --- |
+| License | [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) |
 | Continuous Integration | [![CI Build & Test](https://github.com/paulhuggett/icubaby/actions/workflows/ci.yaml/badge.svg)](https://github.com/paulhuggett/icubaby/actions/workflows/ci.yaml) |
 | Static Analysis | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=paulhuggett_icubaby&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=paulhuggett_icubaby) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/d7aafd88d8ef4be7b03b568e957f0103)](https://app.codacy.com/gh/paulhuggett/icubaby/dashboard) [![CodeQL](https://github.com/paulhuggett/icubaby/actions/workflows/codeql.yaml/badge.svg)](https://github.com/paulhuggett/icubaby/actions/workflows/codeql.yaml) [![Microsoft C++ Code Analysis](https://github.com/paulhuggett/icubaby/actions/workflows/msvc.yaml/badge.svg)](https://github.com/paulhuggett/icubaby/actions/workflows/msvc.yaml) [![Coverity](https://img.shields.io/coverity/scan/29639.svg)](https://scan.coverity.com/projects/paulhuggett-icubaby)
 | Runtime Analysis | [![Fuzz Test](https://github.com/paulhuggett/icubaby/actions/workflows/fuzztest.yaml/badge.svg)](https://github.com/paulhuggett/icubaby/actions/workflows/fuzztest.yaml) [![codecov](https://codecov.io/gh/paulhuggett/icubaby/graph/badge.svg?token=YFO0SOXQE9)](https://codecov.io/gh/paulhuggett/icubaby)

--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -117,14 +117,15 @@
 #endif
 
 /// \brief A macro that evaluates true if the compiler and library have support for C++ 20 concepts.
-#define ICUBABY_HAVE_CONCEPTS \
-  (ICUBABY_CPP_CONCEPTS_DEFINED && __cpp_concepts >= 201907L && ICUBABY_CPP_LIB_CONCEPTS_DEFINED)
+#define ICUBABY_HAVE_CONCEPTS                                                                       \
+  (ICUBABY_CPP_CONCEPTS_DEFINED && __cpp_concepts >= 201907L && ICUBABY_CPP_LIB_CONCEPTS_DEFINED && \
+   __cpp_lib_concepts >= 202002L)
 #if ICUBABY_HAVE_CONCEPTS
 #include <concepts>
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 /// \brief Defined as `requires x` if concepts are supported and as nothing
 ///   otherwise.
 /// \hideinitializer
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define ICUBABY_REQUIRES(x) requires x
 #else
 #define ICUBABY_REQUIRES(x)
@@ -687,6 +688,7 @@ public:
   /// \param well_formed The initial value for the transcoder's "well formed" state.
   explicit constexpr transcoder (bool well_formed) noexcept
       : code_point_{0}, well_formed_{static_cast<uint_least32_t> (well_formed)}, pad_{0}, state_{accept} {
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
     pad_ = 0;  // Suppress warning about pad_ being unused.
   }
 

--- a/tests/demo8/demo8.cpp
+++ b/tests/demo8/demo8.cpp
@@ -91,6 +91,13 @@ template <typename StringType> void show (std::ostream& os, StringType const& st
 
 #endif  // HAVE_CPP_LIB_FORMAT
 
+template <typename StringType> void show (std::ostream& os, std::optional<StringType> const& str) {
+  if (!str) {
+    return;  // do something.
+  }
+  show (os, *str);
+}
+
 std::optional<std::u16string> convert (std::basic_string_view<icubaby::char8> const& src) {
   std::u16string out;
 
@@ -167,18 +174,25 @@ void c5 () {
 int main () {
   icubaby::char8 const* in = u8"こんにちは世界\n";
   show (std::cout, std::basic_string_view (in));
-  show (std::cout, *convert (in));
-  show (std::cout, *convert2 (in));
+  show (std::cout, convert (in));
+  show (std::cout, convert2 (in));
   c3 ();
   c4 ();
   c5 ();
 
+  enum class code_point : char32_t {
+    cjk_unified_ideograph_2070e = char32_t{0x2070E},
+    cjk_unified_ideograph_20731 = char32_t{0x20731},
+    cjk_unified_ideograph_20779 = char32_t{0x20779},
+    cjk_unified_ideograph_20c53 = char32_t{0x20C53},
+  };
+
   icubaby::t32_16 t;
   std::vector<char16_t> out;
   auto it = std::back_inserter (out);
-  it = t (char32_t{0x2070E}, it);
-  it = t (char32_t{0x20731}, it);
-  it = t (char32_t{0x20779}, it);
-  it = t (char32_t{0x20C53}, it);
+  it = t (static_cast<char32_t> (code_point::cjk_unified_ideograph_2070e), it);
+  it = t (static_cast<char32_t> (code_point::cjk_unified_ideograph_20731), it);
+  it = t (static_cast<char32_t> (code_point::cjk_unified_ideograph_20779), it);
+  it = t (static_cast<char32_t> (code_point::cjk_unified_ideograph_20c53), it);
   show (std::cout, out);
 }

--- a/tests/iconv/iconv.cpp
+++ b/tests/iconv/iconv.cpp
@@ -121,10 +121,11 @@ std::vector<C> convert_using_iconv (std::vector<char32_t> const &in) {
     auto const out_size = out.size ();
     auto const out_bytes_available = sizeof (C) * out_size - total_out_bytes;
     auto out_bytes_left = out_bytes_available;
-    // NOLINTNEXTLINE
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-const-cast)
     if (auto *outbuf = pointer_cast<char *> (out.data ()) + total_out_bytes;
         iconv (cd, pointer_cast<char **> (const_cast<from_encoding **> (&inbuf)), &in_bytes_left, &outbuf,
                &out_bytes_left) == static_cast<std::size_t> (-1)) {
+      // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
       // E2BIG tells us that the output buffer was too small.
       if (int const erc = errno; erc != E2BIG) {
         throw std::system_error{std::error_code{erc, std::generic_category ()}, "iconv"};

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -20,14 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <iostream>
+
+#include "icubaby/icubaby.hpp"
+
+#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <iostream>
 #include <iterator>
+#include <ranges>
 #include <vector>
 #include <version>
 
@@ -40,52 +46,7 @@
 #include <iomanip>
 #endif
 
-// Do we have library support for C++ 20 ranges?
-#if defined(__cpp_lib_ranges) && __cpp_lib_ranges > 201811L
-#include <ranges>
-#endif
-
-#include "icubaby/icubaby.hpp"
-
-#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
-
 namespace {
-
-std::array const expected8{
-    char8_t{0xE3}, char8_t{0x81}, char8_t{0x93},                 // U+3053 HIRAGANA LETTER KO
-    char8_t{0xE3}, char8_t{0x82}, char8_t{0x93},                 // U+3093 HIRAGANA LETTER N
-    char8_t{0xE3}, char8_t{0x81}, char8_t{0xAB},                 // U+306B HIRAGANA LETTER NI
-    char8_t{0xE3}, char8_t{0x81}, char8_t{0xA1},                 // U+3061 HIRAGANA LETTER TI
-    char8_t{0xE3}, char8_t{0x81}, char8_t{0xAF},                 // U+306F HIRAGANA LETTER HA
-    char8_t{0xE4}, char8_t{0xB8}, char8_t{0x96},                 // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
-    char8_t{0xE7}, char8_t{0x95}, char8_t{0x8C},                 // U+754C CJK UNIFIED IDEOGRAPH-754C
-    char8_t{0xF0}, char8_t{0x9F}, char8_t{0x98}, char8_t{0x80},  // U+1F600 GRINNING FACE
-    char8_t{0x0A}                                                // U+000A LINE FEED
-};
-
-std::array const expected16{
-    char16_t{0x3053},                    // U+3053 HIRAGANA LETTER KO
-    char16_t{0x3093},                    // U+3093 HIRAGANA LETTER N
-    char16_t{0x306B},                    // U+306B HIRAGANA LETTER NI
-    char16_t{0x3061},                    // U+3061 HIRAGANA LETTER TI
-    char16_t{0x306F},                    // U+306F HIRAGANA LETTER HA
-    char16_t{0x4E16},                    // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
-    char16_t{0x754C},                    // U+754C CJK UNIFIED IDEOGRAPH-754C
-    char16_t{0xD83D}, char16_t{0xDE00},  // U+1F600 GRINNING FACE
-    char16_t{0x000A}                     // U+000A LINE FEED
-};
-
-std::array const expected32{
-    char32_t{0x3053},   // U+3053 HIRAGANA LETTER KO
-    char32_t{0x3093},   // U+3093 HIRAGANA LETTER N
-    char32_t{0x306B},   // U+306B HIRAGANA LETTER NI
-    char32_t{0x3061},   // U+3061 HIRAGANA LETTER TI
-    char32_t{0x306F},   // U+306F HIRAGANA LETTER HA
-    char32_t{0x4E16},   // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
-    char32_t{0x754C},   // U+754C CJK UNIFIED IDEOGRAPH-754C
-    char32_t{0x1F600},  // U+1F600 GRINNING FACE
-    char32_t{0x000A}    // U+000A LINE FEED
-};
 
 template <icubaby::unicode_char_type CharType> struct char_to_output_type {};
 template <> struct char_to_output_type<char8_t> {
@@ -161,11 +122,12 @@ void dump_well_formed (std::ostream& os, bool well_formed) {
 
 template <std::ranges::input_range ActualRange, std::ranges::input_range ExpectedRange>
   requires std::is_same_v<std::ranges::range_value_t<ActualRange>, std::ranges::range_value_t<ExpectedRange>>
-void check (ActualRange const& actual, ExpectedRange const& expected) {
+[[nodiscard]] bool check (ActualRange const& actual, ExpectedRange const& expected) {
   if (!std::ranges::equal (actual, expected)) {
     std::cerr << "Actual range did not equal the expected!\n";
-    std::exit (EXIT_FAILURE);  // NOLINT(concurrency-mt-unsafe)
+    return false;
   }
+  return true;
 }
 
 template <std::ranges::input_range Range>
@@ -238,6 +200,40 @@ std::vector<char8_t> convert_16_to_8 (Range const& in) {
   return out8;
 }
 
+std::array const expected32{
+    char32_t{0x3053},   // U+3053 HIRAGANA LETTER KO
+    char32_t{0x3093},   // U+3093 HIRAGANA LETTER N
+    char32_t{0x306B},   // U+306B HIRAGANA LETTER NI
+    char32_t{0x3061},   // U+3061 HIRAGANA LETTER TI
+    char32_t{0x306F},   // U+306F HIRAGANA LETTER HA
+    char32_t{0x4E16},   // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
+    char32_t{0x754C},   // U+754C CJK UNIFIED IDEOGRAPH-754C
+    char32_t{0x1F600},  // U+1F600 GRINNING FACE
+    char32_t{0x000A}    // U+000A LINE FEED
+};
+std::array const expected16{
+    char16_t{0x3053},                    // U+3053 HIRAGANA LETTER KO
+    char16_t{0x3093},                    // U+3093 HIRAGANA LETTER N
+    char16_t{0x306B},                    // U+306B HIRAGANA LETTER NI
+    char16_t{0x3061},                    // U+3061 HIRAGANA LETTER TI
+    char16_t{0x306F},                    // U+306F HIRAGANA LETTER HA
+    char16_t{0x4E16},                    // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
+    char16_t{0x754C},                    // U+754C CJK UNIFIED IDEOGRAPH-754C
+    char16_t{0xD83D}, char16_t{0xDE00},  // U+1F600 GRINNING FACE
+    char16_t{0x000A}                     // U+000A LINE FEED
+};
+std::array const expected8{
+    char8_t{0xE3}, char8_t{0x81}, char8_t{0x93},                 // U+3053 HIRAGANA LETTER KO
+    char8_t{0xE3}, char8_t{0x82}, char8_t{0x93},                 // U+3093 HIRAGANA LETTER N
+    char8_t{0xE3}, char8_t{0x81}, char8_t{0xAB},                 // U+306B HIRAGANA LETTER NI
+    char8_t{0xE3}, char8_t{0x81}, char8_t{0xA1},                 // U+3061 HIRAGANA LETTER TI
+    char8_t{0xE3}, char8_t{0x81}, char8_t{0xAF},                 // U+306F HIRAGANA LETTER HA
+    char8_t{0xE4}, char8_t{0xB8}, char8_t{0x96},                 // U+4E16 CJK UNIFIED IDEOGRAPH-4E16
+    char8_t{0xE7}, char8_t{0x95}, char8_t{0x8C},                 // U+754C CJK UNIFIED IDEOGRAPH-754C
+    char8_t{0xF0}, char8_t{0x9F}, char8_t{0x98}, char8_t{0x80},  // U+1F600 GRINNING FACE
+    char8_t{0x0A}                                                // U+000A LINE FEED
+};
+
 }  // end anonymous namespace
 
 int main () {
@@ -251,16 +247,24 @@ int main () {
 #endif
 
     auto const out16 = convert_8_to_16 (in);
-    check (out16, expected16);
+    if (!check (out16, expected16)) {
+      exit_code = EXIT_FAILURE;
+    }
 
     auto const out32 = convert_8_to_32 (in);
-    check (out32, expected32);
+    if (!check (out32, expected32)) {
+      exit_code = EXIT_FAILURE;
+    }
 
-    check (convert_32_to_16 (out32), expected16);
-    check (convert_16_to_32 (out16), expected32);
-
-    auto const out8 = convert_16_to_8 (out16);
-    assert (std::ranges::equal (in, out8));
+    if (!check (convert_32_to_16 (out32), expected16)) {
+      exit_code = EXIT_FAILURE;
+    }
+    if (!check (convert_16_to_32 (out16), expected32)) {
+      exit_code = EXIT_FAILURE;
+    }
+    if (!check (convert_16_to_8 (out16), in)) {
+      exit_code = EXIT_FAILURE;
+    }
   } catch (std::exception const& ex) {
     std::cerr << "Error: " << ex.what () << '\n';
     exit_code = EXIT_FAILURE;
@@ -277,4 +281,4 @@ int main () {
   std::cout << "Sorry, icubaby C++ 20 ranges aren't supported by your build.\n";
 }
 
-#endif
+#endif  // ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -164,7 +164,7 @@ template <std::ranges::input_range ActualRange, std::ranges::input_range Expecte
 void check (ActualRange const& actual, ExpectedRange const& expected) {
   if (!std::ranges::equal (actual, expected)) {
     std::cerr << "Actual range did not equal the expected!\n";
-    std::exit (EXIT_FAILURE);
+    std::exit (EXIT_FAILURE);  // NOLINT(concurrency-mt-unsafe)
   }
 }
 

--- a/unittests/encoded_char.hpp
+++ b/unittests/encoded_char.hpp
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef UNITTESTS_ENCODED_CHAR_HPP
-#define UNITTESTS_ENCODED_CHAR_HPP
+#ifndef ICUBABY_UNITTESTS_ENCODED_CHAR_HPP
+#define ICUBABY_UNITTESTS_ENCODED_CHAR_HPP
 
 #include <array>
 
@@ -486,4 +486,4 @@ template <code_point C, typename To, typename OutputIterator> OutputIterator app
   return std::copy (std::begin (code_units), std::end (code_units), out);
 }
 
-#endif  // UNITTESTS_ENCODED_CHAR_HPP
+#endif  // ICUBABY_UNITTESTS_ENCODED_CHAR_HPP

--- a/unittests/test_utility.cpp
+++ b/unittests/test_utility.cpp
@@ -119,8 +119,10 @@ TEST (IsCodePointStart, Utf32) {
 namespace {
 
 struct AsciiUtf8 : testing::Test {
-  std::vector<icubaby::char8> const CUs{'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
+  static std::array<icubaby::char8, 11> const CUs;
 };
+
+std::array<icubaby::char8, 11> const AsciiUtf8::CUs{'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
 
 }  // end anonymous namespace
 
@@ -130,9 +132,11 @@ TEST_F (AsciiUtf8, Length) {
 }
 // NOLINTNEXTLINE
 TEST_F (AsciiUtf8, Index) {
-  auto begin = std::begin (CUs);
-  auto end = std::end (CUs);
+  // NOLINTBEGIN(llvm-qualified-auto,readability-qualified-auto)
+  auto const begin = std::begin (CUs);
+  auto const end = std::end (CUs);
   auto it = begin;
+  // NOLINTEND(llvm-qualified-auto,readability-qualified-auto)
   EXPECT_EQ (it, icubaby::index (begin, end, size_t{0}));
   std::advance (it, 1);
   EXPECT_EQ (it, icubaby::index (begin, end, size_t{1}));
@@ -175,6 +179,8 @@ template <typename T> struct Hiragana : testing::Test {
     it = append<code_point::hiragana_letter_ma, T> (it);
     (void)append<code_point::hiragana_letter_su, T> (it);
   }
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   std::vector<T> CUs;
 };
 
@@ -221,6 +227,7 @@ template <typename T> struct CjkUnifiedIdeographCodePoints : testing::Test {
     (void)append<code_point::cjk_unified_ideograph_20c53, T> (it);
   }
 
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   std::vector<T> CUs;
 };
 

--- a/unittests/typed_test.hpp
+++ b/unittests/typed_test.hpp
@@ -35,7 +35,7 @@
 #if defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
 namespace testing::internal {
 
-template <> constexpr std::string GetTypeName<char8_t> () {
+template <> inline std::string GetTypeName<char8_t> () {
   return "char8_t";
 }
 

--- a/unittests/typed_test.hpp
+++ b/unittests/typed_test.hpp
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef UNITTESTS_TYPED_TEST_HPP
-#define UNITTESTS_TYPED_TEST_HPP
+#ifndef ICUBABY_UNITTESTS_TYPED_TEST_HPP
+#define ICUBABY_UNITTESTS_TYPED_TEST_HPP
 
 #include <gtest/gtest.h>
 
@@ -29,14 +29,13 @@
 
 #include "icubaby/icubaby.hpp"
 
-// TODO: Remove this code!
-// A specialization of the gtest GetTypeName<char8_t>() function. This is
-// required for compiling with Xcode 14.1 where we have a link error due to
-// missing typeinfo for char8_t.
+// TODO(paul): Remove this code!
+// A specialization of the gtest GetTypeName<char8_t>() function. This is required for compiling with (at least)
+// Xcode 14.1/15.2 where we have a link error due to missing typeinfo for char8_t.
 #if defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
 namespace testing::internal {
 
-template <> inline std::string GetTypeName<char8_t> () {
+template <> constexpr std::string GetTypeName<char8_t> () {
   return "char8_t";
 }
 
@@ -44,8 +43,7 @@ template <> inline std::string GetTypeName<char8_t> () {
 #endif
 
 [[noreturn, maybe_unused]] inline void unreachable () {
-  // Uses compiler specific extensions if possible.
-  // Even if no extension is used, undefined behavior is still raised by
+  // Uses compiler specific extensions if possible. Even if no extension is used, undefined behavior is still raised by
   // an empty function body and the noreturn attribute.
 #ifdef __GNUC__  // GCC, Clang, ICC
   __builtin_unreachable ();
@@ -77,4 +75,4 @@ public:
 
 using OutputTypes = testing::Types<icubaby::char8, char16_t, char32_t>;
 
-#endif  // UNITTESTS_TYPED_TEST_HPP
+#endif  // ICUBABY_UNITTESTS_TYPED_TEST_HPP


### PR DESCRIPTION
- Add a license badge.
- Check the value of __cpp_lib_concepts as well as checking that it is defined.
- Improve the unit test header files guard macros. Disable the llvm-header-guard check.
- Enable the cppcoreguidelines-owning-memory check.
- Tidy and improve the Utf8BadInput test fixture.
