### PR TITLE
Update google test. Add PEDANTIC argument to setup_target.

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable (icubaby-unittests
   test_utility.cpp
   typed_test.hpp
 )
-setup_target (icubaby-unittests)
+setup_target (icubaby-unittests PEDANTIC $<NOT:$<BOOL:${ICUBABY_FUZZTEST}>>)
 target_link_libraries (icubaby-unittests PUBLIC icubaby)
 
 target_compile_options (


### PR DESCRIPTION
Setting PEDANTIC to 'No' (cmake boolean false) disables the additional warning options that setup_target() will add by default. This is used to suppress the numerous warnings that result in a build for Google FuzzTest.