### PR TITLE
Tests and tweaks to support byte-transcoder with ranges.

### DIFF
--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -101,5 +101,3 @@ function (setup_target target)
 
 endfunction (setup_target)
 
-
-add_custom_target(genexdebug COMMAND ${CMAKE_COMMAND} -E echo "$<NOT:$<BOOL:Yes>>")

--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -1746,7 +1746,11 @@ private:
     }
 
     /// Returns true if the output buffer is empty and false otherwise.
-    [[nodiscard]] constexpr bool empty () const noexcept { return valid_.empty (); }
+    [[nodiscard]] constexpr bool empty () const noexcept {
+      assert (valid_.begin () >= out_.begin () && valid_.end () <= out_.end () &&
+              "valid_ must point into the out_ array");
+      return valid_.empty ();
+    }
 
     /// Returns the first element from the range of code units forming the current code point.
     [[nodiscard]] constexpr auto& front () const noexcept {

--- a/unittests/test_byte.cpp
+++ b/unittests/test_byte.cpp
@@ -1,4 +1,3 @@
-#include <iterator>
 // MIT License
 //
 // Copyright (c) 2022-2024 Paul Bowen-Huggett
@@ -23,7 +22,6 @@
 
 #include <gmock/gmock.h>
 
-#include <cstddef>
 #include <vector>
 
 #include "icubaby/icubaby.hpp"
@@ -388,11 +386,22 @@ TEST (ByteTranscoder, RangesUtf8BOM) {
   EXPECT_TRUE (range.well_formed ());
 }
 // NOLINTNEXTLINE
-TEST (ByteTranscoder, Utf16BEAndIterMove) {
+TEST (ByteTranscoder, RangesUtf16BE) {
   std::array const input{std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00},
                          std::byte{'A'},  std::byte{0x00}, std::byte{'b'}};
   std::vector<char32_t> output;
 
+  auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
+  (void)std::ranges::copy (range, std::back_inserter (output));
+  EXPECT_THAT (output, ElementsAre (char32_t{'A'}, char32_t{'b'}));
+  EXPECT_TRUE (range.well_formed ());
+}
+// NOLINTNEXTLINE
+TEST (ByteTranscoder, Utf16BEAndIterMove) {
+  std::array const input{std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00},
+                         std::byte{'A'},  std::byte{0x00}, std::byte{'b'}};
+  std::vector<char32_t> output;
+  output.reserve (2);
   auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
   for (std::move_iterator first{range.begin ()}, last{range.end ()}; first != last; ++first) {
     (void)output.emplace_back (iter_move (first));

--- a/unittests/test_byte.cpp
+++ b/unittests/test_byte.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 // MIT License
 //
 // Copyright (c) 2022-2024 Paul Bowen-Huggett
@@ -22,6 +23,7 @@
 
 #include <gmock/gmock.h>
 
+#include <cstddef>
 #include <vector>
 
 #include "icubaby/icubaby.hpp"
@@ -362,6 +364,45 @@ TEST (ByteTranscoder, Utf32FirstByteOfLittleEndianBOM) {
   EXPECT_THAT (output, ElementsAre (icubaby::replacement_char, 'A', 'b', 'c'));
 }
 
+#if ICUBABY_HAVE_RANGES
+// NOLINTNEXTLINE
+TEST (ByteTranscoder, RangesNoBOM) {
+  std::array const input{std::byte{'H'}, std::byte{'e'}, std::byte{'l'}, std::byte{'l'}, std::byte{'o'}};
+  std::vector<char32_t> output;
+
+  auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
+  (void)std::ranges::copy (range, std::back_inserter (output));
+
+  EXPECT_THAT (output, ElementsAre (char32_t{'H'}, char32_t{'e'}, char32_t{'l'}, char32_t{'l'}, char32_t{'o'}));
+  EXPECT_TRUE (range.well_formed ());
+}
+// NOLINENEXTLINE
+TEST (ByteTranscoder, RangesUtf8BOM) {
+  std::array const input{std::byte{0xEF}, std::byte{0xBB}, std::byte{0xBF}, std::byte{'H'}, std::byte{'e'}, std::byte{'l'}, std::byte{'l'}, std::byte{'o'}};
+  std::vector<char32_t> output;
+
+  auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
+  (void)std::ranges::copy (range, std::back_inserter (output));
+
+  EXPECT_THAT (output, ElementsAre (char32_t{'H'}, char32_t{'e'}, char32_t{'l'}, char32_t{'l'}, char32_t{'o'}));
+  EXPECT_TRUE (range.well_formed ());
+}
+// NOLINTNEXTLINE
+TEST (ByteTranscoder, Utf16BEAndIterMove) {
+  std::array const input{std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00},
+                         std::byte{'A'},  std::byte{0x00}, std::byte{'b'}};
+  std::vector<char32_t> output;
+
+  auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
+  for (std::move_iterator<decltype (range)::iterator> first{range.begin ()}, last{range.end ()}; first != last;
+       ++first) {
+    output.emplace_back (iter_move (first));
+  }
+  EXPECT_THAT (output, ElementsAre (char32_t{'A'}, char32_t{'b'}));
+  EXPECT_TRUE (range.well_formed ());
+}
+#endif  // ICUBABY_HAVE_RANGES
+
 #if ICUBABY_FUZZTEST
 static void ByteTranscoderNeverCrashes (std::vector<std::byte> const& input) {
   icubaby::transcoder<std::byte, char32_t> transcoder;
@@ -369,5 +410,6 @@ static void ByteTranscoderNeverCrashes (std::vector<std::byte> const& input) {
   (void)transcoder.end_cp (
       std::copy (std::begin (input), std::end (input), icubaby::iterator{&transcoder, std::back_inserter (output)}));
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (ByteTranscoder, ByteTranscoderNeverCrashes);
 #endif  // ICUBABY_FUZZTEST

--- a/unittests/test_byte.cpp
+++ b/unittests/test_byte.cpp
@@ -394,9 +394,8 @@ TEST (ByteTranscoder, Utf16BEAndIterMove) {
   std::vector<char32_t> output;
 
   auto range = input | icubaby::ranges::transcode<std::byte, char32_t>;
-  for (std::move_iterator<decltype (range)::iterator> first{range.begin ()}, last{range.end ()}; first != last;
-       ++first) {
-    output.emplace_back (iter_move (first));
+  for (std::move_iterator first{range.begin ()}, last{range.end ()}; first != last; ++first) {
+    (void)output.emplace_back (iter_move (first));
   }
   EXPECT_THAT (output, ElementsAre (char32_t{'A'}, char32_t{'b'}));
   EXPECT_TRUE (range.well_formed ());


### PR DESCRIPTION
- Remove the genexdebug target. 
- Fix iter_move definition. 
- Add ranges byte-transcoder tests.