### PR TITLE
Limit line length, refactor CMakeLists.txt. Improve naming.

### DIFF
--- a/examples/.clang-format
+++ b/examples/.clang-format
@@ -1,0 +1,20 @@
+
+---
+BasedOnStyle : Google
+
+AccessModifierOffset    : -2
+ColumnLimit             : 80
+CommentPragmas          :  '^\\.+'
+SpaceBeforeParens       : Always
+SpaceInEmptyParentheses : false
+Standard                : c++20
+
+AllowShortBlocksOnASingleLine       : false
+AllowShortCaseLabelsOnASingleLine   : true
+AllowShortEnumsOnASingleLine        : true
+AllowShortFunctionsOnASingleLine    : InlineOnly
+AllowShortIfStatementsOnASingleLine : false
+AllowShortLambdasOnASingleLine      : true
+AllowShortLoopsOnASingleLine        : false
+AlwaysBreakTemplateDeclarations     : MultiLine
+IndentCaseLabels                    : false

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,15 +1,42 @@
-add_executable (icubaby-example-view-utf32-to-16 view_utf32_to_16.cpp)
-target_link_libraries (icubaby-example-view-utf32-to-16 PRIVATE icubaby)
-setup_target (icubaby-example-view-utf32-to-16)
+# MIT License
+#
+# Copyright (c) 2022-2024 Paul Bowen-Huggett
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
-add_executable (icubaby-example-bytes-to-utf8 bytes_to_utf8.cpp)
-target_link_libraries (icubaby-example-bytes-to-utf8 PRIVATE icubaby)
-setup_target (icubaby-example-bytes-to-utf8)
+include (setup_target)
 
-add_executable (icubaby-example-utf8-to-16-iterator iterator.cpp)
-target_link_libraries (icubaby-example-utf8-to-16-iterator PRIVATE icubaby)
-setup_target (icubaby-example-utf8-to-16-iterator)
+function (add_example target)
+  cmake_parse_arguments (
+    arg # prefix
+    "" # options
+    "" # one-value-keywords
+    "SOURCES" # multi-value-keywords
+    ${ARGN}
+  )
+  set (actual_target "icubaby-example-${target}")
+  add_executable ("${actual_target}" ${arg_SOURCES})
+  target_link_libraries ("${actual_target}" PUBLIC icubaby)
+  setup_target ("${actual_target}")
+endfunction (add_example)
 
-add_executable (icubaby-example-manual-bytes-to-utf8 manual_bytes_to_utf8.cpp)
-target_link_libraries (icubaby-example-manual-bytes-to-utf8 PRIVATE icubaby)
-setup_target (icubaby-example-manual-bytes-to-utf8)
+add_example (view-utf32-to-16 SOURCES view_utf32_to_16.cpp)
+add_example (bytes-to-utf8 SOURCES bytes_to_utf8.cpp)
+add_example (utf8-to-16-iterator SOURCES iterator.cpp)
+add_example (manual-bytes-to-utf8 SOURCES manual_bytes_to_utf8.cpp)

--- a/examples/bytes_to_utf8.cpp
+++ b/examples/bytes_to_utf8.cpp
@@ -2,28 +2,36 @@
 
 #include "icubaby/icubaby.hpp"
 
-// The ICUBABY_HAVE_RANGES and ICUBABY_HAVE_CONCEPTS macros are true if the corresponding features are available
-// in both the compiler and standard library.
+// The ICUBABY_HAVE_RANGES and ICUBABY_HAVE_CONCEPTS macros are true if the
+// corresponding features are available in both the compiler and standard
+// library.
 #if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
 
 int main () {
-  // The bytes to be converted. An array here, but this could obviously come from any source such as user input, a
-  // file, or a network endpoint. Note that the icubaby transcoder deals with a single byte at a time so we don't
+  // The bytes to be converted. An array here, but this could obviously come
+  // from any source such as user input, a file, or a network endpoint. Note
+  // that the icubaby transcoder deals with a single byte at a time so we don't
   // need to have the entire input available at any time.
   static std::array const input{
-      std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00}, std::byte{'H'}, std::byte{0x00}, std::byte{'e'},
-      std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'l'}, std::byte{0x00}, std::byte{'o'},
-      std::byte{0x00}, std::byte{' '},  std::byte{0x00}, std::byte{'W'}, std::byte{0x00}, std::byte{'o'},
-      std::byte{0x00}, std::byte{'r'},  std::byte{0x00}, std::byte{'l'}, std::byte{0x00}, std::byte{'d'},
+      std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00}, std::byte{'H'},
+      std::byte{0x00}, std::byte{'e'},  std::byte{0x00}, std::byte{'l'},
+      std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'o'},
+      std::byte{0x00}, std::byte{' '},  std::byte{0x00}, std::byte{'W'},
+      std::byte{0x00}, std::byte{'o'},  std::byte{0x00}, std::byte{'r'},
+      std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'d'},
   };
 
-  // A pipeline where the input array is converted from a series of bytes to a stream of UTF-8 code units
-  // and then finally to std::uint_least8_t for display to the user.
+  // A pipeline where the input array is converted from a series of bytes to a
+  // stream of UTF-8 code units and then finally to std::uint_least8_t for
+  // display to the user.
   auto range = input | icubaby::views::transcode<std::byte, char8_t> |
-               std::views::transform ([] (char8_t code_unit) { return static_cast<std::uint_least8_t> (code_unit); });
+               std::views::transform ([] (char8_t code_unit) {
+                 return static_cast<std::uint_least8_t> (code_unit);
+               });
 
   // Copy the elements of range directly to `std::cout`.
-  (void)std::ranges::copy (range, std::ostream_iterator<std::uint_least8_t> (std::cout));
+  (void)std::ranges::copy (
+      range, std::ostream_iterator<std::uint_least8_t> (std::cout));
 }
 
 #else

--- a/examples/iterator.cpp
+++ b/examples/iterator.cpp
@@ -8,22 +8,28 @@
 namespace {
 
 // Dump the number of code units and code points within the supplied container.
-template <typename Container> void describe (Container const& container, std::string_view const encoding) {
+template <typename Container>
+void describe (Container const& container, std::string_view const encoding) {
   auto const code_units = container.size ();
-  auto const code_points = icubaby::length (std::begin (container), std::end (container));
+  auto const code_points =
+      icubaby::length (std::begin (container), std::end (container));
 
-  std::cout << encoding << " is " << code_units << ' ' << (code_units == 1U ? "code unit" : "code units") << " and "
-            << code_points << ' ' << (code_points == 1U ? "code point" : "code points") << '\n';
+  std::cout << encoding << " is " << code_units << ' '
+            << (code_units == 1U ? "code unit" : "code units") << " and "
+            << code_points << ' '
+            << (code_points == 1U ? "code point" : "code points") << '\n';
 }
 
 }  // end anonymous namespace
 
 int main () {
-  // The input: we start with a vector of UTF-8 code units. In this case a single U+1F600 GRINNING FACE code point.
-  // Note that we use icubaby::char8 here for compatibility with C++ 17. If you always use C++ 20 or later, you can
-  // bypass this type and simply use char8_t.
-  auto const input = std::vector{static_cast<icubaby::char8> (0xF0), static_cast<icubaby::char8> (0x9F),
-                                 static_cast<icubaby::char8> (0x98), static_cast<icubaby::char8> (0x80)};
+  // The input: we start with a vector of UTF-8 code units. In this case a
+  // single U+1F600 GRINNING FACE code point. Note that we use icubaby::char8
+  // here for compatibility with C++ 17. If you always use C++ 20 or later, you
+  // can bypass this type and simply use char8_t.
+  auto const input = std::vector{
+      static_cast<icubaby::char8> (0xF0), static_cast<icubaby::char8> (0x9F),
+      static_cast<icubaby::char8> (0x98), static_cast<icubaby::char8> (0x80)};
   describe (input, "UTF-8");
 
   // A second vector which will contain the UTF-16 output.
@@ -32,13 +38,15 @@ int main () {
   // Instantiate a transcoder which can convert from UTF-8 to UTF-16.
   icubaby::t8_16 transcoder;
 
-  // Now an output iterator based on the t8_16 transcoder which can consume UTF-8 input and convert it to UTF-16. It
-  // will then emit the results to a second output iterator (`inserter`) which appends those code units to the `output`
-  // vector.
+  // Now an output iterator based on the t8_16 transcoder which can consume
+  // UTF-8 input and convert it to UTF-16. It will then emit the results to a
+  // second output iterator (`inserter`) which appends those code units to the
+  // `output` vector.
   auto inserter = std::back_inserter (output);
   auto output_it = icubaby::iterator{&transcoder, inserter};
 
-  // Loop through the input assigning each UTF-16 to the `it` output iterator created on the previous line.
+  // Loop through the input assigning each UTF-16 to the `it` output iterator
+  // created on the previous line.
   for (auto code_unit : input) {
     *(output_it++) = code_unit;
   }
@@ -47,5 +55,6 @@ int main () {
   (void)transcoder.end_cp (output_it);
 
   describe (output, "UTF-16");
-  std::cout << "Input " << (transcoder.well_formed () ? "was" : "was not") << " well formed\n";
+  std::cout << "Input " << (transcoder.well_formed () ? "was" : "was not")
+            << " well formed\n";
 }

--- a/examples/manual_bytes_to_utf8.cpp
+++ b/examples/manual_bytes_to_utf8.cpp
@@ -5,36 +5,43 @@
 #include "icubaby/icubaby.hpp"
 
 int main () {
-  // The bytes to be converted. An array here, but this could obviously come from any source such as user input, a
-  // file, or a network endpoint. Note that the icubaby transcoder deals with a single byte at a time so we don't
+  // The bytes to be converted. An array here, but this could obviously come
+  // from any source such as user input, a file, or a network endpoint. Note
+  // that the icubaby transcoder deals with a single byte at a time so we don't
   // need to have the entire input available at any time.
-  static std::array const input{std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00}, std::byte{'H'},  std::byte{0x00},
-                                std::byte{'e'},  std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'l'},
-                                std::byte{0x00}, std::byte{'o'},  std::byte{0x00}, std::byte{' '},  std::byte{0x00},
-                                std::byte{'W'},  std::byte{0x00}, std::byte{'o'},  std::byte{0x00}, std::byte{'r'},
-                                std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'d'},  std::byte{0x00},
-                                std::byte{'\n'}};
+  static std::array const input{
+      std::byte{0xFE}, std::byte{0xFF}, std::byte{0x00}, std::byte{'H'},
+      std::byte{0x00}, std::byte{'e'},  std::byte{0x00}, std::byte{'l'},
+      std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'o'},
+      std::byte{0x00}, std::byte{' '},  std::byte{0x00}, std::byte{'W'},
+      std::byte{0x00}, std::byte{'o'},  std::byte{0x00}, std::byte{'r'},
+      std::byte{0x00}, std::byte{'l'},  std::byte{0x00}, std::byte{'d'},
+      std::byte{0x00}, std::byte{'\n'}};
 
   // A vector to contain the UTF-8 output.
   std::vector<icubaby::char8> output;
 
-  // An output iterator that will append each UTF-8 code unit to the `output` vector.
+  // An output iterator that will append each UTF-8 code unit to the `output`
+  // vector.
   auto out_it = std::back_inserter (output);
 
-  // The transcoder instance. We consume bytes (indicating that the transcoder must decide on the input encoding)
-  // and emit icubaby::char8 (UTF-8).
+  // The transcoder instance. We consume bytes (indicating that the transcoder
+  // must decide on the input encoding) and emit icubaby::char8 (UTF-8).
   icubaby::transcoder<std::byte, icubaby::char8> transcode;
 
-  // Call the transcoder for each source byte. Output goes to the 'out' output iterator.
+  // Call the transcoder for each source byte. Output goes to the 'out' output
+  // iterator.
   for (auto b : input) {
     out_it = transcode (b, out_it);
   }
 
-  // Tell the transoder that it should have received a complete code point. This always happens at the end of the input.
+  // Tell the transoder that it should have received a complete code point. This
+  // always happens at the end of the input.
   (void)transcode.end_cp (out_it);
 
-  // Write the output to the console. This example sticks to the ASCII subset of code point, so this should work on most terminals!
-  for (auto c: output) {
+  // Write the output to the console. This example sticks to the ASCII subset of
+  // code point, so this should work on most terminals!
+  for (auto c : output) {
     std::cout << static_cast<char> (c);
   }
 }

--- a/examples/view_utf32_to_16.cpp
+++ b/examples/view_utf32_to_16.cpp
@@ -4,17 +4,19 @@
 
 #include "icubaby/icubaby.hpp"
 
-// The ICUBABY_HAVE_RANGES and ICUBABY_HAVE_CONCEPTS macros are true if the corresponding features are available
-// in both the compiler and standard library.
+// The ICUBABY_HAVE_RANGES and ICUBABY_HAVE_CONCEPTS macros are true if the
+// corresponding features are available in both the compiler and standard
+// library.
 #if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
 
 int main () {
-  // The code points to be converted. Here just a single U+1F600 GRINNING FACE emoji but obviously the array
-  // could contain many more code points.
-  auto const in = std::array{char32_t{0x1F600}};
+  // The code points to be converted. Here just a single U+1F600 GRINNING FACE
+  // emoji but obviously the array could contain many more code points.
+  auto const input = std::array{char32_t{0x1F600}};
 
-  // Take the 'in' container and send it lazily through a UTF-32 to UTF-16 transcoder.
-  auto r = in | icubaby::views::transcode<char32_t, char16_t>;
+  // Take the 'input' container and send it lazily through a UTF-32 to UTF-16
+  // transcoder.
+  auto r = input | icubaby::views::transcode<char32_t, char16_t>;
 
   // A vector to contain the output UTF=16 code units.
   std::vector<char16_t> out;


### PR DESCRIPTION
Add a .clang-format file which limits the line length to 80 characters. This should enable the examples to be more easily read in the documentation. Reformat the files accordingly.

Give a coule of variables names that are at least three characters.

Refactor CMakeLists.txt to eliminate duplication between the example targets.