### PR TITLE
Fix compile error when composing  with e.g. std::views::transform()

### DIFF
--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -2085,7 +2085,7 @@ public:
   using difference_type = std::ranges::range_difference_t<View>;
 
   iterator () requires std::default_initializable<std::ranges::iterator_t<View>> = default;
-  constexpr iterator (transcode_view const& parent, std::ranges::iterator_t<View> const& current)
+  constexpr iterator (transcode_view const& parent, std::ranges::iterator_t<View const> const& current)
       : current_{current}, parent_{&parent}, state_{current} {
     assert (state_.empty ());
     // Prime the input state so that a dereference of the iterator will yield the first of the
@@ -2135,7 +2135,7 @@ private:
     /// \brief Initializes the state and primes the internal buffer with an initial code-point read from the input.
     ///
     /// \param iter  An iterator referencing the next element in the input range to be consumed.
-    constexpr explicit state (std::ranges::iterator_t<View> iter) : next_{std::move (iter)} {}
+    constexpr explicit state (std::ranges::iterator_t<View const> iter) : next_{std::move (iter)} {}
     constexpr state () = default;
 
     /// Returns true if the output buffer is empty and false otherwise.
@@ -2163,7 +2163,7 @@ private:
     ///
     /// \param parent  The view from which input values are to be consumed.
     /// \returns The updated base iterator.
-    constexpr std::ranges::iterator_t<View> fill (transcode_view const* parent);
+    constexpr std::ranges::iterator_t<View const> fill (transcode_view const* parent);
 
   private:
     /// The type of the output buffer. This is sized so that it allows for the largest nunber of bytes that the
@@ -2173,7 +2173,7 @@ private:
     using iterator = typename out_type::iterator;
 
     /// An iterator referencing the next input code-unit to be consumed.
-    std::ranges::iterator_t<View> next_{};
+    std::ranges::iterator_t<View const> next_{};
     /// The container into which the transcoder's output will be written.
     out_type out_{};
     /// The transcoder used to convert a series of code-units in the source encoding to the destination encoding.
@@ -2194,14 +2194,14 @@ private:
     /// Together with the last_ field, determines the code-units to be produced when the view is dereferenced.
     std::uint_least8_t last_ : valid_range_bits = 0;
   };
-  std::ranges::iterator_t<View> current_{};
+  std::ranges::iterator_t<View const> current_{};
   transcode_view const* parent_ = nullptr;
   mutable state state_{};
 };
 
 template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
   requires std::ranges::view<View>
-constexpr std::ranges::iterator_t<View> transcode_view<FromEncoding, ToEncoding, View>::iterator::state::fill (
+constexpr std::ranges::iterator_t<View const> transcode_view<FromEncoding, ToEncoding, View>::iterator::state::fill (
     transcode_view const* parent) {
   auto result = next_;
   assert (this->empty () && "out_ was not empty when fill called");

--- a/unittests/encoded_char.hpp
+++ b/unittests/encoded_char.hpp
@@ -29,6 +29,10 @@
 
 enum class code_point : char32_t {
   cent_sign = char32_t{0x00A2},
+  digit_zero = char32_t{0x0030},
+  digit_one = char32_t{0x0031},
+  digit_two = char32_t{0x0032},
+  digit_three = char32_t{0x0033},
   cjk_unified_ideograph_2070e = char32_t{0x2070E},
   cjk_unified_ideograph_20731 = char32_t{0x20731},
   cjk_unified_ideograph_20779 = char32_t{0x20779},
@@ -128,6 +132,46 @@ template <> struct encoded_char<code_point::cent_sign, char16_t> {
 };
 template <> struct encoded_char<code_point::cent_sign, icubaby::char8> {
   static constexpr std::array value{static_cast<icubaby::char8> (0xC2), static_cast<icubaby::char8> (0xA2)};
+};
+
+template <> struct encoded_char<code_point::digit_zero, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::digit_zero)};
+};
+template <> struct encoded_char<code_point::digit_zero, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::digit_zero)};
+};
+template <> struct encoded_char<code_point::digit_zero, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (code_point::digit_zero)};
+};
+
+template <> struct encoded_char<code_point::digit_one, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::digit_one)};
+};
+template <> struct encoded_char<code_point::digit_one, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::digit_one)};
+};
+template <> struct encoded_char<code_point::digit_one, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (code_point::digit_one)};
+};
+
+template <> struct encoded_char<code_point::digit_two, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::digit_two)};
+};
+template <> struct encoded_char<code_point::digit_two, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::digit_two)};
+};
+template <> struct encoded_char<code_point::digit_two, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (code_point::digit_two)};
+};
+
+template <> struct encoded_char<code_point::digit_three, char32_t> {
+  static constexpr std::array value{static_cast<char32_t> (code_point::digit_three)};
+};
+template <> struct encoded_char<code_point::digit_three, char16_t> {
+  static constexpr std::array value{static_cast<char16_t> (code_point::digit_three)};
+};
+template <> struct encoded_char<code_point::digit_three, icubaby::char8> {
+  static constexpr std::array value{static_cast<icubaby::char8> (code_point::digit_three)};
 };
 
 template <> struct encoded_char<code_point::pilcrow_sign, char32_t> {

--- a/unittests/test_u8.cpp
+++ b/unittests/test_u8.cpp
@@ -581,6 +581,22 @@ TYPED_TEST (Utf8, RangesBadInput) {
   (void)append<code_point::replacement_char, TypeParam> (std::back_inserter (expected));
   EXPECT_THAT (output, ContainerEq (expected));
 }
+// NOLINTNEXTLINE
+TYPED_TEST (Utf8, RangesCompose) {
+  auto& output = this->output_;
+  (void)std::ranges::copy (std::views::iota (0, 4) | std::views::transform ([] (int value) {
+                             return static_cast<char8_t> (value) + '0';
+                           }) | icubaby::views::transcode<char8_t, TypeParam>,
+                           std::back_inserter (output));
+
+  std::vector<TypeParam> expected;
+  auto expected_out = std::back_inserter (expected);
+  expected_out = append<code_point::digit_zero, TypeParam> (expected_out);
+  expected_out = append<code_point::digit_one, TypeParam> (expected_out);
+  expected_out = append<code_point::digit_two, TypeParam> (expected_out);
+  expected_out = append<code_point::digit_three, TypeParam> (expected_out);
+  EXPECT_THAT (output, ContainerEq (expected));
+}
 
 #endif  // __cpp_lib_ranges
 


### PR DESCRIPTION
Prior to this change attempting to compose std::views::transform() and icubaby::views::transcoder would result in a compile error because the View type need to be treated as const. (This was observed with Xcode 15.3.)