### PR TITLE
Pin the branch-names action to a specific commit.

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get branch names
         id: branch-names
-        uses: tj-actions/branch-names@v8
+        uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2 # v8.0.1
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
We pin to the commit associated with tag v8.0.1