### PR TITLE
Add clang-18 build. Use paulhuggett/install-llvm.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,27 +26,30 @@ jobs:
           # Ubuntu builds
           # ~~~~~~~~~~~~~
           - name: Ubuntu-22.04/gcc-13/Debug
-            apt_install: g++-13 libstdc++-13-dev ninja-build
+            apt_install: ninja-build
             build_type: Debug
             cxx_compiler: -D CMAKE_CXX_COMPILER=g++-13 -D CMAKE_C_COMPILER=gcc-13
+            gcc_install: 13
             options: -D ICUBABY_SANITIZE=Yes
             generator: Unix Makefiles
             os: ubuntu-22.04
             package: TGZ
 
           - name: Ubuntu-22.04/gcc-13/RelWithDebug/Sanitizers
-            apt_install: g++-13 libstdc++-13-dev ninja-build
+            apt_install: ninja-build
             build_type: RelWithDebug
             cxx_compiler: -D CMAKE_CXX_COMPILER=g++-13 -D CMAKE_C_COMPILER=gcc-13
+            gcc_install: 13
             options: -D ICUBABY_SANITIZE=Yes
             generator: Unix Makefiles
             os: ubuntu-22.04
             package: TGZ
 
           - name: Ubuntu-22.04/gcc-13/Release
-            apt_install: g++-13 libstdc++-13-dev ninja-build
+            apt_install: ninja-build
             build_type: Release
             cxx_compiler: -D CMAKE_CXX_COMPILER=g++-13 -D CMAKE_C_COMPILER=gcc-13
+            gcc_install: 13
             generator: Unix Makefiles
             os: ubuntu-22.04
             package: TGZ
@@ -66,6 +69,26 @@ jobs:
             llvm_install: 16
             build_type: Release
             cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-16 -D CMAKE_C_COMPILER=clang-16
+            generator: Ninja
+            options:
+            os: ubuntu-22.04
+            package: TGZ
+
+          - name: Ubuntu-22.04/clang-18/Debug
+            apt_install: cmake ninja-build
+            llvm_install: 18
+            build_type: Debug
+            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-18 -D CMAKE_C_COMPILER=clang-18
+            generator: Ninja
+            options: -D ICUBABY_SANITIZE=Yes
+            os: ubuntu-22.04
+            package: TGZ
+
+          - name: Ubuntu-22.04/clang-18/Release
+            apt_install: cmake ninja-build
+            llvm_install: 18
+            build_type: Release
+            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-18 -D CMAKE_C_COMPILER=clang-18
             generator: Ninja
             options:
             os: ubuntu-22.04
@@ -104,7 +127,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           submodules: 'True'
 
@@ -114,15 +137,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt_install }}
 
+      - name: Install Dependencies (GCC)
+        if: matrix.gcc_install != ''
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt install -y "gcc-${{ matrix.gcc_install }}" \
+                              "libstdc++-${{ matrix.gcc_install }}-dev"
+
       - name: Install Dependencies (LLVM)
         if: matrix.llvm_install != ''
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          # Force --yes to the end of the add-apt-repository command to
-          # prevent the llvm.sh script hanging.
-          sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.llvm_install}}
+        uses: paulhuggett/install-llvm@ad897b4b1cf03f54c1218ec6d97a23ff4b10b870 # v1.0
+        with:
+          version: ${{matrix.llvm_install}}
 
       - name: Create Build Environment
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           submodules: 'True'
 

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -44,6 +44,7 @@ function (setup_target target)
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
     -Wno-c99-extensions
+    -Wno-covered-switch-default
     -Wno-ctad-maybe-unsupported
     -Wno-documentation-unknown-command
     -Wno-exit-time-destructors

--- a/unittests/test_byte.cpp
+++ b/unittests/test_byte.cpp
@@ -44,6 +44,7 @@ void PrintTo (encoding enc, std::ostream* os) {
   case encoding::utf16le: str = "utf16le"; break;
   case encoding::utf32be: str = "utf32be"; break;
   case encoding::utf32le: str = "utf32le"; break;
+  default: str = "**error**"; break;
   }
   *os << str;
 }


### PR DESCRIPTION
Explicitly install gcc-13 to enable use with 'nektos act'. Resolve 'switch' missing 'default' warning from clang-18.