### PR TITLE
Option hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,16 @@ jobs:
             os: macos-12
             package: TGZ
 
-          - name: macOS-14/arm64/Xcode/Debug
+          - name: macOS-14/Xcode/Debug
             build_type: Debug
             generator: Xcode
-            os: macos-14-arm64
+            os: macos-14
+            package: TGZ
+
+          - name: macOS-14/Xcode/Release
+            build_type: Release
+            generator: Xcode
+            os: macos-14
             package: TGZ
 
           # Ubuntu builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,12 @@ jobs:
             os: macos-12
             package: TGZ
 
+          - name: macOS-14/arm64/Xcode/Debug
+            build_type: Debug
+            generator: Xcode
+            os: macos-14-arm64
+            package: TGZ
+
           # Ubuntu builds
           # ~~~~~~~~~~~~~
           - name: Ubuntu-22.04/gcc-13/Debug

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -59,11 +59,15 @@ function (setup_target target)
 
   set (gcc_warning_options
     -Wall
-    -Wbidi-chars=any
     -Wextra
     -Wtrampolines
     -pedantic
   )
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GCC")
+    check_cxx_compiler_flag (-Wbidi-chars=any GCC_W_BIDI_CHARS)
+    list (APPEND gcc_warning_options $<$<BOOL:${GCC_W_BIDI_CHARS}>:-Wbidi-chars=any)
+  endif()
+
   set (msvc_warning_options
     -W4
     -wd4324 # 4324: structure was padded due to alignment specifier

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -59,7 +59,9 @@ function (setup_target target)
 
   set (gcc_warning_options
     -Wall
+    -Wbidi-chars=any
     -Wextra
+    -Wtrampolines
     -pedantic
   )
   set (msvc_warning_options
@@ -67,6 +69,26 @@ function (setup_target target)
     -wd4324 # 4324: structure was padded due to alignment specifier
     -wd4068 # 4068: unknown pragma
   )
+
+  # TODO: On AArch64 use -mbranch-protection=standard?
+  set (clang_options
+    -fstack-protector-strong
+    -fcf-protection=full
+  )
+  set (gcc_options
+    -fstack-clash-protection
+    -fstack-protector-strong
+    -fcf-protection=full
+    -fPIE
+    -pie
+    -U_FORTIFY_SOURCE
+    -D_FORTIFY_SOURCE=3
+  )
+
+  if (LINUX)
+    list (APPEND clang_options -fstack-clash-protection)
+    list (APPEND gcc_options -fstack-clash-protection)
+  endif (LINUX)
 
   if (ICUBABY_WERROR)
     list (APPEND clang_options -Werror)
@@ -89,12 +111,31 @@ function (setup_target target)
   list (APPEND gcc_options   $<$<BOOL:${arg_PEDANTIC}>:${gcc_warning_options}>)
   list (APPEND msvc_options  $<$<BOOL:${arg_PEDANTIC}>:${msvc_warning_options}>)
 
+  set (clang_definitions
+    _GLIBCXX_ASSERTIONS
+    _LIB_CPP_ASSERT
+    _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG
+  )
+  set (gcc_definitions
+    _GLIBCXX_ASSERTIONS
+    _LIB_CPP_ASSERT
+    _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG
+  )
+  set(msvc_definitions )
+
   target_compile_options (${target} PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:IntelLLVM>>:${clang_options}>
     $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
     $<$<CXX_COMPILER_ID:MSVC>:${msvc_options}>
   )
-  target_compile_definitions (${target} PUBLIC ICUBABY_FUZZTEST=$<BOOL:${ICUBABY_FUZZTEST}>)
+
+  target_compile_definitions (${target} PRIVATE ICUBABY_FUZZTEST=$<BOOL:${ICUBABY_FUZZTEST}>)
+  target_compile_definitions (${target} PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:IntelLLVM>>:${clang_definitions}>
+    $<$<CXX_COMPILER_ID:GNU>:${gcc_definitions}>
+    $<$<CXX_COMPILER_ID:MSVC>:${msvc_definitions}>
+  )
+
   target_compile_features (${target} PUBLIC $<IF:$<BOOL:${ICUBABY_CXX17}>,cxx_std_17,cxx_std_20>)
   target_link_options (${target} PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:IntelLLVM>>:${clang_options}>
@@ -108,5 +149,25 @@ function (setup_target target)
     target_link_options (${target} PRIVATE "-Wl,-Map=$<TARGET_FILE_DIR:${target}>/map.txt")
   endif ()
 
+  # Restrict dlopen(3) calls to shared objects. Supported since binutils 2.10.
+  check_linker_flag (CXX "-Wl,-z,nodlopen" nodlopen_supported)
+  if (nodlopen_supported)
+    target_link_options (${target} PRIVATE "-Wl,-z,nodlopen")
+  endif ()
+  # Enable data execution prevention by marking stack memory as non-executable. Supported since binutils 2.14.
+  check_linker_flag (CXX "-Wl,-z,noexecstack" noexecstack_supported)
+  if (noexecstack_supported)
+      target_link_options (${target} PRIVATE "-Wl,-z,noexecstack")
+  endif()
+  # Mark relocation table entries resolved at load- time as read-only. Supported since binutils 2.15.
+  check_linker_flag (CXX "-Wl,-z,relro" relro_supported)
+  if (relro_supported)
+      target_link_options (${target} PRIVATE "-Wl,-z,relro")
+  endif ()
+  # Mark relocation table entries resolved at load- time as read-only. Disable lazy binding. Supported since binutils 2.15.
+  check_linker_flag (CXX "-Wl,-z,now" now_supported)
+  if (now_supported)
+      target_link_options (${target} PRIVATE "-Wl,-z,now")
+  endif()
 endfunction (setup_target)
 

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -70,15 +70,12 @@ function (setup_target target)
     -wd4068 # 4068: unknown pragma
   )
 
-  # TODO: On AArch64 use -mbranch-protection=standard?
   set (clang_options
     -fstack-protector-strong
-    -fcf-protection=full
   )
   set (gcc_options
     -fstack-clash-protection
     -fstack-protector-strong
-    -fcf-protection=full
     -fPIE
     -pie
     -U_FORTIFY_SOURCE
@@ -86,8 +83,9 @@ function (setup_target target)
   )
 
   if (LINUX)
-    list (APPEND clang_options -fstack-clash-protection)
-    list (APPEND gcc_options -fstack-clash-protection)
+    # TODO: On AArch64 use -mbranch-protection=standard?
+    list (APPEND clang_options -fstack-clash-protection -fcf-protection=full)
+    list (APPEND gcc_options  -fstack-clash-protection -fcf-protection=full)
   endif (LINUX)
 
   if (ICUBABY_WERROR)


### PR DESCRIPTION
Based on the advice in the [OpenSSF Compiler Hardening Guide](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html), add suggested switches to improve security of the binaries in this project.