### PR TITLE
Enable undef warning

### DIFF
--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -46,9 +46,7 @@ function (setup_target target)
     -Wno-c99-extensions
     -Wno-ctad-maybe-unsupported
     -Wno-documentation-unknown-command
-    -Wno-exit-time-destructors
     -Wno-padded
-    -Wno-undef
   )
   # Some clang warning switches are not available in all versions of the compiler.
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")

--- a/tests/demo8/demo8.cpp
+++ b/tests/demo8/demo8.cpp
@@ -162,7 +162,7 @@ void c5 () {
                          static_cast<icubaby::char8> (0x98), static_cast<icubaby::char8> (0x80)};
   std::vector<char16_t> out;
   icubaby::t8_16 transcoder;
-#if __cpp_lib_ranges
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201811L
   auto out_it = std::ranges::copy (input, icubaby::iterator{&transcoder, std::back_inserter (out)}).out;
 #else
   auto out_it =

--- a/tests/demo8/demo8.cpp
+++ b/tests/demo8/demo8.cpp
@@ -33,6 +33,7 @@
 #include <format>
 #else
 // We're lacking std::format(). Fall back to using iostreams manipulators.
+#define HAVE_CPP_LIB_FORMAT (0)
 #include <iomanip>
 #endif
 

--- a/tests/ranges/ranges.cpp
+++ b/tests/ranges/ranges.cpp
@@ -43,6 +43,7 @@
 #include <format>
 #else
 // We're lacking std::format(). Fall back to using iostreams manipulators.
+#define HAVE_CPP_LIB_FORMAT (0)
 #include <iomanip>
 #endif
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_compile_options (
   PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
       -Wno-global-constructors
+      -Wno-undef
       -Wno-used-but-marked-unused>
     $<$<CXX_COMPILER_ID:GNU>:>
     # -wd4702 : unreachable code.


### PR DESCRIPTION
Enable the -Wno-exit-time-destructors and -Wno-undef clang warnings.