### PR TITLE
transcoder<>::partial() is a non-static const member function.

### DIFF
--- a/include/icubaby/icubaby.hpp
+++ b/include/icubaby/icubaby.hpp
@@ -763,7 +763,7 @@ public:
   [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
   /// \returns True if a partial code-point has been passed to operator() and
   /// false otherwise.
-  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+  [[nodiscard]] constexpr bool partial () const noexcept { return false; }
 
 private:
   /// True if the input consumed is well formed, false otherwise.
@@ -1006,7 +1006,7 @@ public:
   [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
   /// \returns True if a partial code-point has been passed to operator() and
   /// false otherwise.
-  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+  [[nodiscard]] constexpr bool partial () const noexcept { return false; }
 
 private:
   /// True if the input consumed is well formed, false otherwise.
@@ -1978,7 +1978,7 @@ public:
   [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
   /// \returns True if a partial code-point has been passed to operator() and
   /// false otherwise.
-  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+  [[nodiscard]] constexpr bool partial () const noexcept { return false; }
 
 private:
   /// True if the input consumed is well formed, false otherwise.


### PR DESCRIPTION
There were three instances where transcoder<>::partial() was a static member function because the function simply returns a constant. However, the transcoder interface has this as a non-static const member function and I think it's important that all of the implementations have exactly the same interface. This change may cause some static analysis warnings, but they can be ignored.