### PR TITLE
Limit the events that will trigger the CI workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,13 @@
 name: CI Build & Test
-# Triggers the workflow on push or pull request events
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+  workflow_dispatch:
+
 permissions:
   contents: read
 

--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -1,11 +1,10 @@
 name: Codacy Clang-Tidy
+
 on:
   push:
-    branches:
-      - main
-      - v2
   pull_request:
     types: [opened, synchronize, reopened]
+
 permissions:
   contents: read
 

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -2,8 +2,11 @@ name: Fuzz Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [assigned, opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This should ensure that we waste fewer runs and less time.