### PR TITLE
Use compile-commands rather than build-wrapper-output.

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -114,7 +114,6 @@ jobs:
             --define sonar.branch.name="${{ steps.branch-names.outputs.current_branch }}"    \
             --define sonar.branch.target="${{ steps.branch-names.outputs.base_ref_branch }}" \
             --define sonar.cfamily.compile-commands="$WRAPPER_OUT/compile_commands.json"     \
-            --define sonar.cfamily.llvm-cov.reportPath="$COVERAGE"                           \
             --define sonar.exclusions="$BUILD_DIR/**/*,docs/**/*"                            \
             --define sonar.host.url="$SONAR_SERVER_URL"                                      \
             --define sonar.organization=paulhuggett-github                                   \
@@ -122,3 +121,5 @@ jobs:
             --define sonar.projectVersion="$(git rev-parse HEAD)"                            \
             --define sonar.python.version=3.7,3.8,3.9,3.10,3.11                              \
             --define sonar.sourceEncoding=UTF-8
+            # Disabled due to exception from Sonar.
+            #--define sonar.cfamily.llvm-cov.reportPath="$COVERAGE"

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -21,8 +21,8 @@ jobs:
     env:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       # Directory where build-wrapper output will be placed
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
-      CLANG_VERSION: 16
+      WRAPPER_OUT: build_wrapper_output_directory
+      CLANG_VERSION: 18
       BUILD_DIR: build
       COVERAGE: "./coverage.txt"
 
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-          submodules: 'True'
+          submodules: True
 
       - name: Get branch names
         id: branch-names
@@ -56,48 +56,49 @@ jobs:
 
       - name: CMake Configure
         run: |
-          mkdir ${{ env.BUILD_DIR }}
-          cmake -G Ninja                                           \
-                -S .                                               \
-                -B ${{ env.BUILD_DIR }}                            \
-                -D ICUBABY_COVERAGE=Yes                            \
-                -D CMAKE_C_COMPILER=clang-${{ env.CLANG_VERSION }} \
-                -D CMAKE_CXX_COMPILER=clang++-${{ env.CLANG_VERSION }}
+          mkdir "$BUILD_DIR"
+          cmake -G Ninja                                   \
+                -S .                                       \
+                -B "$BUILD_DIR"                            \
+                -D ICUBABY_COVERAGE=Yes                    \
+                -D "CMAKE_C_COMPILER=clang-$CLANG_VERSION" \
+                -D "CMAKE_CXX_COMPILER=clang++-$CLANG_VERSION"
 
       - name: Build
         run: |
-          build-wrapper-linux-x86-64                   \
-            --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} \
-            cmake --build ${{ env.BUILD_DIR }} --config Release
+          build-wrapper-linux-x86-64           \
+            --out-dir "$WRAPPER_OUT" \
+            cmake --build "$BUILD_DIR" --config Release
 
       - name: Run Test Tools
         run: |
           set -v
           TESTS="\
-            tests/iconv/iconv-test \
-            tests/ranges/ranges    \
-            tests/demo8/demo8      \
+            tests/iconv/iconv-test             \
+            tests/ranges/ranges                \
+            tests/demo8/demo8                  \
             tests/exhaust/icubaby-exhaust-test \
+            tests/performance/performance      \
             unittests/icubaby-unittests"
           for f in $TESTS; do
-            P="${{ env.BUILD_DIR }}/$f"
+            P="$BUILD_DIR/$f"
             LLVM_PROFILE_FILE="$P.profraw" $P
           done
 
       - name: Index the Raw Profiles
         run: |
-          find ${{ env.BUILD_DIR }} -name \*.profraw -print0 |
+          find "$BUILD_DIR" -name \*.profraw -print0 |
           xargs -0 \
-            llvm-profdata-${{ env.CLANG_VERSION }}    \
-              merge                                   \
-              -o ${{ env.BUILD_DIR }}/merged.profdata \
+            "llvm-profdata-$CLANG_VERSION"    \
+              merge                           \
+              -o "$BUILD_DIR/merged.profdata" \
               -sparse
 
       - name: Collect Coverage
         run: |
           { \
-            find ${{ env.BUILD_DIR }} -name CMakeFiles -prune -type f -or -type f -perm -u=x -print0 | \
-              xargs -0 -n 1 llvm-cov-${{ env.CLANG_VERSION }} show --instr-profile build/merged.profdata
+            find "$BUILD_DIR" -name CMakeFiles -prune -type f -or -type f -perm -u=x -print0 | \
+              xargs -0 -n 1 "llvm-cov-$CLANG_VERSION" show --instr-profile build/merged.profdata
           } > "$COVERAGE"
 
       - name: Run sonar-scanner
@@ -112,14 +113,12 @@ jobs:
             -X                                                                               \
             --define sonar.branch.name="${{ steps.branch-names.outputs.current_branch }}"    \
             --define sonar.branch.target="${{ steps.branch-names.outputs.base_ref_branch }}" \
-            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"   \
-            --define sonar.exclusions='${{ env.BUILD_DIR }}/**/*,docs/**/*'                  \
-            --define sonar.host.url="${{ env.SONAR_SERVER_URL }}"                            \
+            --define sonar.cfamily.compile-commands="$WRAPPER_OUT/compile_commands.json"     \
+            --define sonar.cfamily.llvm-cov.reportPath="$COVERAGE"                           \
+            --define sonar.exclusions="$BUILD_DIR/**/*,docs/**/*"                            \
+            --define sonar.host.url="$SONAR_SERVER_URL"                                      \
             --define sonar.organization=paulhuggett-github                                   \
             --define sonar.projectKey=paulhuggett_icubaby                                    \
             --define sonar.projectVersion="$(git rev-parse HEAD)"                            \
             --define sonar.python.version=3.7,3.8,3.9,3.10,3.11                              \
             --define sonar.sourceEncoding=UTF-8
-            # disable coverage due to error from Sonar.
-            # --define sonar.cfamily.llvm-cov.reportPath="$COVERAGE"
-


### PR DESCRIPTION
Sonar has deprecated the latter setting. Use `$x` rather than `${{ env.x }}`. Renable coverage analysis.