### PR TITLE
Call add_test() for each of the test executables.

### DIFF
--- a/tests/demo8/CMakeLists.txt
+++ b/tests/demo8/CMakeLists.txt
@@ -23,3 +23,4 @@
 add_executable (demo8 demo8.cpp)
 target_link_libraries (demo8 PUBLIC icubaby)
 setup_target (demo8)
+add_test (NAME demo8 COMMAND demo8)

--- a/tests/exhaust/CMakeLists.txt
+++ b/tests/exhaust/CMakeLists.txt
@@ -23,6 +23,7 @@
 add_executable (icubaby-exhaust-test exhaust.cpp)
 target_link_libraries (icubaby-exhaust-test PUBLIC icubaby)
 setup_target (icubaby-exhaust-test)
+add_test (NAME icubaby-exhaust-test COMMAND icubaby-exhaust-test)
 
 if (TARGET gtest)
   set (ICUBABY_TEST_TARGET icubaby-unittests)

--- a/tests/iconv/CMakeLists.txt
+++ b/tests/iconv/CMakeLists.txt
@@ -28,4 +28,5 @@ if (Iconv_FOUND)
 
   set (ICUBABY_CXX17 Yes)  # Force this project to C++17.
   setup_target (iconv-test)
+  add_test (NAME iconv-test COMMAND iconv-test)
 endif (Iconv_FOUND)

--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -30,3 +30,4 @@
 add_executable (performance performance.cpp)
 setup_target (performance)
 target_link_libraries (performance PUBLIC icubaby)
+add_test (NAME performance COMMAND performance)

--- a/tests/ranges/CMakeLists.txt
+++ b/tests/ranges/CMakeLists.txt
@@ -23,3 +23,4 @@
 add_executable (ranges ranges.cpp)
 setup_target (ranges)
 target_link_libraries (ranges PUBLIC icubaby)
+add_test (NAME ranges COMMAND ranges)


### PR DESCRIPTION
Calling add_test() enables [ctest](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html) to run the test.