### PR TITLE
Add "standalone" build which includes the test executables.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,6 +190,7 @@ jobs:
                 -G "${{ matrix.generator }}"                 \
                 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 -D ICUBABY_EXAMPLES=Yes                      \
+                -D ICUBABY_STANDALONE=Yes                    \
                 -D ICUBABY_WERROR=Yes                        \
                 ${{ matrix.cxx_compiler }}                   \
                 ${{ matrix.options }}

--- a/.github/workflows/codacy.yaml
+++ b/.github/workflows/codacy.yaml
@@ -65,7 +65,8 @@ jobs:
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=Yes           \
                 -D "CMAKE_C_COMPILER=clang-$CLANG_VERSION"     \
                 -D "CMAKE_CXX_COMPILER=clang++-$CLANG_VERSION" \
-                -D ICUBABY_EXAMPLES=Yes
+                -D ICUBABY_EXAMPLES=Yes                        \
+                -D ICUBABY_STANDALONE=Yes
 
       - name: Run clang-tidy
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -39,6 +39,7 @@ jobs:
             -S .                                     \
             -B "$BUILD_DIR"                          \
             -D ICUBABY_COVERAGE=Yes                  \
+            -D ICUBABT_STANDALONE=Yes                \
             -D CMAKE_C_COMPILER="gcc-$GCC_VERSION"   \
             -D CMAKE_CXX_COMPILER="g++-$GCC_VERSION"
 

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -75,7 +75,8 @@ jobs:
           cmake                         \
             -S .                        \
             -B ./build                  \
-            -D CMAKE_BUILD_TYPE=Release
+            -D CMAKE_BUILD_TYPE=Release \
+            -D ICUBABY_STANDALONE=Yes
 
       - name: Build
         run: |

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -49,7 +49,8 @@ jobs:
             -D CMAKE_BUILD_TYPE="$BUILD_TYPE"              \
             -D CMAKE_CXX_COMPILER="clang++-$CLANG_VERSION" \
             -D CMAKE_C_COMPILER="clang-$CLANG_VERSION"     \
-            -D ICUBABY_FUZZTEST=Yes
+            -D ICUBABY_FUZZTEST=Yes                        \
+            -D ICUBABY_STANDALONE=Yes
 
       - name: Build
         run: |

--- a/.github/workflows/msvc.yaml
+++ b/.github/workflows/msvc.yaml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -B ${{ env.build }}                   \
-                -D CMAKE_BUILD_TYPE=${{ env.config }} \
+          cmake -B ${{ env.build }}                   `
+                -D CMAKE_BUILD_TYPE=${{ env.config }} `
                 -D ICUBABY_STANDALONE=Yes
 
       # Build is not required unless generated source files are used

--- a/.github/workflows/msvc.yaml
+++ b/.github/workflows/msvc.yaml
@@ -47,7 +47,10 @@ jobs:
           submodules: 'True'
 
       - name: Configure CMake
-        run: cmake -B ${{ env.build }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+        run: |
+          cmake -B ${{ env.build }}                   \
+                -D CMAKE_BUILD_TYPE=${{ env.config }} \
+                -D ICUBABY_STANDALONE=Yes
 
       # Build is not required unless generated source files are used
       # - name: Build CMake

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -61,6 +61,7 @@ jobs:
                 -S .                                       \
                 -B "$BUILD_DIR"                            \
                 -D ICUBABY_COVERAGE=Yes                    \
+                -D ICUBABY_STANDALONE=Yes                  \
                 -D "CMAKE_C_COMPILER=clang-$CLANG_VERSION" \
                 -D "CMAKE_CXX_COMPILER=clang++-$CLANG_VERSION"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option (ICUBABY_EXAMPLES "Include example code in the generated build")
 option (ICUBABY_FUZZTEST "Enable FuzzTest")
 option (ICUBABY_LIBCXX "Use libc++ rather than libstdc++ (clang only)")
 option (ICUBABY_SANITIZE "Enable undefined behavior- and address-sanitizers where supported")
+option (ICUBABY_STANDALONE "A standalone build includes test executables")
 option (ICUBABY_WERROR "Compiler warnings are errors")
 
 set (icubaby_project_root "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -99,7 +100,10 @@ endif (ICUBABY_EXAMPLES)
 
 # tests
 
-add_subdirectory (tests)
+if (ICUBABY_STANDALONE)
+    add_subdirectory (tests)
+endif (ICUBABY_STANDALONE)
+
 if (TARGET gtest)
   add_subdirectory (unittests)
 endif ()


### PR DESCRIPTION
Standalone mode defaults to off for clients.