### PR TITLE
Ignore the env.build directory.

### DIFF
--- a/.github/workflows/msvc.yaml
+++ b/.github/workflows/msvc.yaml
@@ -65,7 +65,7 @@ jobs:
           buildConfiguration: ${{ env.config }}
           # Ruleset file that will determine what checks will be run
           ruleset: NativeRecommendedRules.ruleset
-          ignoredTargetPaths: ${{ github.workspace }}/googletest;${{ github.workspace }}/unittests
+          ignoredTargetPaths: ${{ env.build }};${{ github.workspace }}/unittests
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub


### PR DESCRIPTION
Don't analyse code in the build tree: this now includes dependencies from makes FetchContent.